### PR TITLE
Runtime optimizations and bug fixing

### DIFF
--- a/src/fedex_generator/Measures/BaseMeasure.py
+++ b/src/fedex_generator/Measures/BaseMeasure.py
@@ -315,7 +315,10 @@ class BaseMeasure(object):
 
 
     def _calc_influence(self, score_dict, max_col_name, results_columns) -> pd.DataFrame:
-        results = pd.DataFrame([], columns=results_columns)
+        # This silly initialization is done because of the way pandas works with concatenation.
+        # Concatenating an empty dataframe with another dataframe is deprecated, so we initialize it with a single empty row.
+        # This row will be dropped later.
+        results = pd.DataFrame([["", "", "", "", "", ""]], columns=results_columns)
         source_name, bins, score, _ = score_dict[max_col_name]
 
         for current_bin in bins.bins:
@@ -344,6 +347,7 @@ class BaseMeasure(object):
                                        current_bin.get_bin_name(), max_col_name]))
                 results = pd.concat([results, pd.DataFrame([new_result])], ignore_index=True)
 
+        results = results.drop(axis='index', index=0)
         return results
 
 

--- a/src/fedex_generator/Measures/BaseMeasure.py
+++ b/src/fedex_generator/Measures/BaseMeasure.py
@@ -1,4 +1,5 @@
 import math
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Dict, List, Tuple, Any
 import matplotlib
 import matplotlib.pyplot as plt
@@ -119,8 +120,45 @@ class BaseMeasure(object):
 
         return source_col, res_col
 
-    def calc_measure(self, operation_object: Operation, scheme: dict, use_only_columns: list, ignore: list = []) -> \
-    Dict[str, float]:
+
+    def _calc_measure(self, attr: str, dataset_relation: DatasetRelation, operation_object: Operation, scheme: dict,
+                      use_only_columns: list, ignore=None) \
+            -> Tuple[str, float, str, Bins, Tuple[pd.Series, pd.Series]] | Tuple[str, float, None, None, None]:
+        # If the attribute is in the ignore list, skip it.
+        if attr in ignore:
+            return attr, -1, None, None, None
+
+        # Get the column scheme from the scheme dictionary. If not found, set it to 'ni'.
+        column_scheme = scheme.get(attr, "ni").lower()
+        # If the column scheme is 'i', skip the attribute.
+        if column_scheme == "i":
+            return attr, -1, None, None, None
+
+        # If there are columns in the use_only_columns list, and the attribute is not in the list, skip it.
+        if len(use_only_columns) > 0 and attr not in use_only_columns:
+            return attr, -1, None, None, None
+
+        # Get the source and result columns for the attribute.
+        source_col, res_col = self.get_source_and_res_cols(dataset_relation, attr)
+        # If the result column is empty, skip the attribute.
+        if len(res_col) == 0:
+            return attr, -1, None, None, None
+
+        # Create bin candidates from the source and result columns, with a bin count specified by the operation object.
+        size = operation_object.get_bins_count()
+
+        bin_candidates = Bins(source_col, res_col, size)
+
+        # Compute the measure score for each bin candidate, and get the maximum score.
+        measure_score = -np.inf
+        for bin_ in bin_candidates.bins:
+            measure_score = max(self.calc_measure_internal(bin_), measure_score)
+
+
+        return attr, measure_score, dataset_relation.get_source_name(), bin_candidates, (source_col, res_col)
+
+    def calc_measure(self, operation_object: Operation, scheme: dict, use_only_columns: list, ignore=None) -> \
+            Dict[str, float]:
         """
         Calculate the measure for each attribute in the operation_object.
 
@@ -131,48 +169,25 @@ class BaseMeasure(object):
         """
         # Set the operation object, the scheme, and the score dictionary to the given values.
         # Also initialize the max_val to -1.
+        if ignore is None:
+            ignore = []
+
         self.operation_object = operation_object
         self.score_dict = {}
         self.max_val = -1
         self.scheme = scheme
 
         # Iterate over the attributes in the operation object.
-        for attr, dataset_relation in operation_object.iterate_attributes():
-            # If the attribute is in the ignore list, skip it.
-            if attr in ignore:
-                continue
-
-            # Get the column scheme from the scheme dictionary. If not found, set it to 'ni'.
-            column_scheme = scheme.get(attr, "ni").lower()
-            # If the column scheme is 'i', skip the attribute.
-            if column_scheme == "i":
-                continue
-
-            # If there are columns in the use_only_columns list, and the attribute is not in the list, skip it.
-            if len(use_only_columns) > 0 and attr not in use_only_columns:
-                continue
-
-            # Get the source and result columns for the attribute.
-            source_col, res_col = self.get_source_and_res_cols(dataset_relation, attr)
-            # If the result column is empty, skip the attribute.
-            if len(res_col) == 0:
-                continue
-
-            # Create bin candidates from the source and result columns, with a bin count specified by the operation object.
-            size = operation_object.get_bins_count()
-
-            bin_candidates = Bins(source_col, res_col, size)
-
-            # Compute the measure score for each bin candidate, and get the maximum score.
-            measure_score = -np.inf
-            for bin_ in bin_candidates.bins:
-                measure_score = max(self.calc_measure_internal(bin_), measure_score)
-
-            # Update the score dictionary with the attribute, the source name,
-            # the bin candidates, the measure score,
-            # and the source and result columns after computing the measure score.
-            self.score_dict[attr] = (
-                dataset_relation.get_source_name(), bin_candidates, measure_score, (source_col, res_col))
+        # From limited testing, doing this in parallel gives a small performance boost.
+        with ThreadPoolExecutor() as executor:
+            futures = [
+                executor.submit(self._calc_measure, attr, dataset_relation, operation_object, scheme, use_only_columns,
+                                ignore) for attr, dataset_relation in operation_object.iterate_attributes()
+            ]
+            for future in as_completed(futures):
+                attr, measure_score, source_name, bins, cols = future.result()
+                if measure_score != -1:
+                    self.score_dict[attr] = (source_name, bins, measure_score, cols)
 
         # Get the maximum value from the score dictionary and set it to the max_val attribute.
         self.max_val = max([kl_val for _, _, kl_val, _ in self.score_dict.values()])
@@ -298,6 +313,40 @@ class BaseMeasure(object):
 
         return (influence - influence_mean) / np.sqrt(influence_var)
 
+
+    def _calc_influence(self, score_dict, max_col_name, results_columns) -> pd.DataFrame:
+        results = pd.DataFrame([], columns=results_columns)
+        source_name, bins, score, _ = score_dict[max_col_name]
+
+        for current_bin in bins.bins:
+            # Compute the influence values for the current bin.
+            influence_vals = self.get_influence_col(current_bin)
+            influence_vals_list = np.array(list(influence_vals.values()))
+
+            # If all the influence values are NaN, skip the current bin.
+            if np.all(np.isnan(influence_vals_list)):
+                continue
+
+            # Get the top k (1 in this case) attribute indexes and their corresponding influence values.
+            max_values, max_influences = self.get_max_k(influence_vals, 1)
+
+            # Iterate over the top k attributes and their influence values.
+            # Compute the significance of the influence value, and if it is above the threshold, build an explanation.
+            for max_value, influence_val in zip(max_values, max_influences):
+                significance = self.get_significance(influence_val, influence_vals_list)
+                if significance < SIGNIFICANCE_THRESHOLD:
+                    continue
+                explanation = self.build_explanation(current_bin, max_col_name, max_value, source_name)
+
+                # Save the results in a dictionary and append it to the results dataframe.
+                new_result = dict(zip(results_columns,
+                                      [score, significance, influence_val, explanation, current_bin, influence_vals,
+                                       current_bin.get_bin_name(), max_col_name]))
+                results = pd.concat([results, pd.DataFrame([new_result])], ignore_index=True)
+
+        return results
+
+
     def calc_influence(self, brute_force=False, top_k=TOP_K_DEFAULT,
                        figs_in_row: int = DEFAULT_FIGS_IN_ROW, show_scores: bool = False, title: str = None,
                        deleted=None) -> matplotlib.pyplot.Figure | List[matplotlib.pyplot.Figure]:
@@ -343,34 +392,14 @@ class BaseMeasure(object):
         figures = []
 
         # Iterate over the top K attributes, and get the influence values for each bin.
-        for score, max_col_name, bins, _ in list_scores_sorted[:-K - 1:-1]:
-            source_name, bins, score, _ = score_dict[max_col_name]
-
-            for current_bin in bins.bins:
-                # Compute the influence values for the current bin.
-                influence_vals = self.get_influence_col(current_bin)
-                influence_vals_list = np.array(list(influence_vals.values()))
-
-                # If all the influence values are NaN, skip the current bin.
-                if np.all(np.isnan(influence_vals_list)):
-                    continue
-
-                # Get the top k (1 in this case) attribute indexes and their corresponding influence values.
-                max_values, max_influences = self.get_max_k(influence_vals, 1)
-
-                # Iterate over the top k attributes and their influence values.
-                # Compute the significance of the influence value, and if it is above the threshold, build an explanation.
-                for max_value, influence_val in zip(max_values, max_influences):
-                    significance = self.get_significance(influence_val, influence_vals_list)
-                    if significance < SIGNIFICANCE_THRESHOLD:
-                        continue
-                    explanation = self.build_explanation(current_bin, max_col_name, max_value, source_name)
-
-                    # Save the results in a dictionary and append it to the results dataframe.
-                    new_result = dict(zip(results_columns,
-                                          [score, significance, influence_val, explanation, current_bin, influence_vals,
-                                           current_bin.get_bin_name(), max_col_name]))
-                    results = pd.concat([results, pd.DataFrame([new_result])], ignore_index=True)
+        # From limited testing, doing this in parallel gives a small performance boost.
+        with ThreadPoolExecutor() as executor:
+            futures = [
+                executor.submit(self._calc_influence, score_dict, max_col_name, results_columns)
+                for score, max_col_name, bins, _ in list_scores_sorted[:-K - 1:-1]
+            ]
+            for future in as_completed(futures):
+                results = pd.concat([results, future.result()], ignore_index=True)
 
         # Compute the skyline of the results dataframe.
         results_skyline = results[results_columns[0:2]].astype("float")
@@ -381,6 +410,8 @@ class BaseMeasure(object):
         bins = results[skyline]["bin"]
         influence_vals = results[skyline]["influence_vals"]
         scores = results[skyline]["score"]
+
+        source_name = score_dict[list_scores_sorted[-1][1]][0]
 
         # If there are no interesting explanations, print a message and return.
         if len(scores) == 0:

--- a/src/fedex_generator/Measures/ExceptionalityMeasure.py
+++ b/src/fedex_generator/Measures/ExceptionalityMeasure.py
@@ -138,7 +138,7 @@ class ExceptionalityMeasure(BaseMeasure):
         s = s[s == s]
         r = np.array(r)
         r = r[r == r]
-        return 0 if len(r) == 0 else utils.ks_2samp(s, r).statistic
+        return 0 if (len(r) == 0 or len(s) == 0) else utils.ks_2samp(s, r).statistic
 
     def calc_influence_col(self, current_bin: Bin):
         # Get the source and result columns

--- a/src/fedex_generator/Operations/Filter.py
+++ b/src/fedex_generator/Operations/Filter.py
@@ -170,6 +170,7 @@ class Filter(Operation.Operation):
 
         :return: explain figures
         """
+        source_df_backup, result_df_backup = None, None
 
         if use_sampling:
             source_df_backup, result_df_backup = self.source_df, self.result_df
@@ -181,28 +182,19 @@ class Filter(Operation.Operation):
         if schema is None:
             schema = {}
 
-        # if use_sampling:
-        #     source_df_backup, result_df_backup = self.source_df, self.result_df
-        #     self.source_df, self.result_df = self.sample(self.source_df), self.sample(self.result_df)
-
         # The measure used for filer operations is always the ExceptionalityMeasure.
         measure = ExceptionalityMeasure()
-        scores = measure.calc_measure(self, schema, attributes)
+        scores = measure.calc_measure(self, schema, attributes, unsampled_source_df=source_df_backup, unsampled_res_df=result_df_backup)
 
         self.delete_correlated_atts(measure, TH=corr_TH)
-        if use_sampling:
-            self.source_df, self.result_df = source_df_backup, result_df_backup
         # Get the explanation figures.
         figures = measure.calc_influence(utils.max_key(scores), top_k=top_k, figs_in_row=figs_in_row,
                                          show_scores=show_scores, title=title)
         if figures:
             self.correlated_notes(figures, top_k)
 
-        # Uncomment this line and remove the above copy of it to use sampling for the entire explanation process,
-        # and not just when computing the measure. This may be needed if it seems calc_influence takes too long
-        # when not using sampling. From some testing, it seems fine, but some more testing may be needed.
-        # if use_sampling:
-        #     self.source_df, self.result_df = source_df_backup, result_df_backup
+        if use_sampling:
+            self.source_df, self.result_df = source_df_backup, result_df_backup
 
         return None
 

--- a/src/fedex_generator/Operations/Filter.py
+++ b/src/fedex_generator/Operations/Filter.py
@@ -62,6 +62,10 @@ class Filter(Operation.Operation):
             self.result_name = utils.get_calling_params_name(result_df)
 
         if use_sampling:
+            # If sampling is used, we want to have a backup of the original source and result DataFrames, for
+            # any potential future need of them.
+            self.unsampled_source_df = source_df
+            self.unsampled_result_df = self.result_df
             self.source_df = self.sample(self.source_df)
             self.result_df = self.sample(self.result_df)
         self.source_name = utils.get_calling_params_name(source_df)

--- a/src/fedex_generator/Operations/GroupBy.py
+++ b/src/fedex_generator/Operations/GroupBy.py
@@ -70,7 +70,8 @@ class GroupBy(Operation.Operation):
     def explain(self, schema: dict=None, attributes: List[str]=None, top_k: int=TOP_K_DEFAULT, explainer: str='fedex',
                 target=None, dir: str | int=None, control=None, hold_out=[],
                 figs_in_row: int = DEFAULT_FIGS_IN_ROW, show_scores: bool = False, title: str = None,
-                corr_TH: float = 0.7, consider='right', cont=None, attr=None, ignore=[], use_sampling=True):
+                corr_TH: float = 0.7, consider='right', cont=None, attr=None, ignore=[],
+                use_sampling=True, sample_size: int | float = Operation.SAMPLE_SIZE):
         """
         Explain for group by operation
         :param schema: dictionary with new columns names, in case {'col_name': 'i'} will be ignored in the explanation
@@ -80,14 +81,11 @@ class GroupBy(Operation.Operation):
         :param figs_in_row: number of explanations figs in one row
         :param title: explanation title
         :param dir: direction of the outlier. Can be 'high' or 'low', or the corresponding integer values 1 and -1 (HIGH and LOW constants).
-        :param use_sampling: whether to use sampling for the explanation
+        :param use_sampling: whether to use sampling for the explanation.
+        :param sample_size: the sample size to use when sampling the data. Can be an integer or a float between 0 and 1. Default is 5000.
 
         :return: explain figures
         """
-
-        if use_sampling:
-            backup_source_df, backup_res_df = self.source_df, self.result_df
-            self.source_df, self.result_df = self.sample(self.source_df), self.sample(self.result_df)
 
         if explainer == 'outlier':
             res_col = None
@@ -124,14 +122,24 @@ class GroupBy(Operation.Operation):
         if attributes is None:
             attributes = []
 
+
+        if use_sampling:
+            backup_source_df, backup_res_df = self.source_df, self.result_df
+            self.source_df, self.result_df = self.sample(self.source_df), self.sample(self.result_df)
+
         # Unless the outlier explainer is used, the diversity measure is always used for the groupby operation.
         measure = DiversityMeasure()
         scores = measure.calc_measure(self, schema, attributes, ignore=ignore)
+        if use_sampling:
+            self.source_df, self.result_df = backup_source_df, backup_res_df
         figures = measure.calc_influence(utils.max_key(scores), top_k=top_k, figs_in_row=figs_in_row,
                                          show_scores=show_scores, title=title)
 
-        if use_sampling:
-            self.source_df, self.result_df = backup_source_df, backup_res_df
+        # Uncomment this line and remove the above copy of it to use sampling for the entire explanation process,
+        # and not just when computing the measure. This may be needed if it seems calc_influence takes too long
+        # when not using sampling. From some testing, it seems fine, but some more testing may be needed.
+        # if use_sampling:
+        #     self.source_df, self.result_df = backup_source_df, backup_res_df
 
         return figures
 

--- a/src/fedex_generator/Operations/GroupBy.py
+++ b/src/fedex_generator/Operations/GroupBy.py
@@ -48,13 +48,19 @@ class GroupBy(Operation.Operation):
             self.result_df = source_df.groupby(group_attributes).agg(agg_dict)
         else:
             self.result_df = result_df
+
             self.result_name = utils.get_calling_params_name(result_df)
 
         # We can't sample a DataFrameGroupBy. If the result is one, there should still be steps to perform,
         # which will create a new GroupBy object.
         if use_sampling and not isinstance(self.result_df, DataFrameGroupBy):
+            # If sampling is used, we want to keep an unsampled version of the source and result
+            # DataFrame for any future need we may have of it.
+            self.unsampled_source_df = source_df
+            self.unsampled_result_df = result_df
             self.source_df = self.sample(self.source_df)
             self.result_df = self.sample(self.result_df)
+
 
     def iterate_attributes(self) -> Generator[Tuple[str, DatasetRelation], None, None]:
         """

--- a/src/fedex_generator/Operations/GroupBy.py
+++ b/src/fedex_generator/Operations/GroupBy.py
@@ -123,23 +123,20 @@ class GroupBy(Operation.Operation):
             attributes = []
 
 
+        backup_source_df, backup_res_df = None, None
         if use_sampling:
             backup_source_df, backup_res_df = self.source_df, self.result_df
             self.source_df, self.result_df = self.sample(self.source_df), self.sample(self.result_df)
 
         # Unless the outlier explainer is used, the diversity measure is always used for the groupby operation.
         measure = DiversityMeasure()
-        scores = measure.calc_measure(self, schema, attributes, ignore=ignore)
-        if use_sampling:
-            self.source_df, self.result_df = backup_source_df, backup_res_df
+        scores = measure.calc_measure(self, schema, attributes, ignore=ignore, unsampled_source_df=backup_source_df,
+                                      unsampled_res_df=backup_res_df)
         figures = measure.calc_influence(utils.max_key(scores), top_k=top_k, figs_in_row=figs_in_row,
                                          show_scores=show_scores, title=title)
 
-        # Uncomment this line and remove the above copy of it to use sampling for the entire explanation process,
-        # and not just when computing the measure. This may be needed if it seems calc_influence takes too long
-        # when not using sampling. From some testing, it seems fine, but some more testing may be needed.
-        # if use_sampling:
-        #     self.source_df, self.result_df = backup_source_df, backup_res_df
+        if use_sampling:
+            self.source_df, self.result_df = backup_source_df, backup_res_df
 
         return figures
 

--- a/src/fedex_generator/Operations/Join.py
+++ b/src/fedex_generator/Operations/Join.py
@@ -46,6 +46,10 @@ class Join(Operation.Operation):
         self.right_name = right_name
         self.left_name = left_name
         if use_sampling:
+            # If sampling is used, we store the original, unsampled dataframes, for any future use.
+            self.unsampled_left_df = left_df
+            self.unsampled_right_df = right_df
+            self.unsampled_result_df = result_df
             self.left_df = self.sample(left_df)
             self.right_df = self.sample(right_df)
             self.result_df = self.sample(result_df)

--- a/src/fedex_generator/Operations/Operation.py
+++ b/src/fedex_generator/Operations/Operation.py
@@ -58,13 +58,25 @@ class Operation:
         """
         return NotImplementedError()
 
-    def sample(self, df: pd.DataFrame, sample_size: int = SAMPLE_SIZE) -> pd.DataFrame:
+    def sample(self, df: pd.DataFrame, sample_size: int | float = SAMPLE_SIZE) -> pd.DataFrame:
         """
         Uniformly sample the dataframe to the given sample size.
         :param df: The dataframe to sample.
-        :param sample_size: The sample size to use. Default is SAMPLE_SIZE.
+        :param sample_size: The sample size to use. Default is SAMPLE_SIZE. If the sample size is below 1,
+         it is considered a percentage of the dataframe size.
         :return: The sampled dataframe.
         """
+        # If the sample size is below 1, we consider it to be a percentage of the dataframe size.
+        if sample_size <= 0:
+            raise ValueError("Sample size must be a positive number.")
+        if 0 < sample_size < 1:
+            sample_size = df.shape[0] * sample_size
+        # If the sample size is below the default sample size, we use the default sample size.
+        # We do this because we know, from empirical testing, that our default size is a good balance between
+        # performance and accuracy, and going below that size can lead to too big a loss in accuracy for
+        # a very small gain in performance.
+        if sample_size < SAMPLE_SIZE:
+            sample_size = SAMPLE_SIZE
         if df.shape[0] <= sample_size:
             return df
         else:

--- a/src/fedex_generator/Operations/Operation.py
+++ b/src/fedex_generator/Operations/Operation.py
@@ -4,14 +4,15 @@ import numpy as np
 
 from fedex_generator.commons.consts import TOP_K_DEFAULT, DEFAULT_FIGS_IN_ROW
 
+SAMPLE_SIZE = 5000
+RANDOM_SEED = 42
+
 
 class Operation:
     """
     An abstract class for operations within the FEDEx explainability framework.\n
     All implemented operations should inherit from this class.
     """
-
-    SAMPLE_SIZE = 5000
 
     def __init__(self, scheme: dict):
         """
@@ -67,5 +68,7 @@ class Operation:
         if df.shape[0] <= sample_size:
             return df
         else:
-            uniform_indexes = np.random.choice(df.index, sample_size, replace=False)
+            # We use a set seed so that the user will always get the same explanation when using sampling.
+            generator = np.random.default_rng(RANDOM_SEED)
+            uniform_indexes = generator.choice(df.index, sample_size, replace=False)
             return df.loc[uniform_indexes]

--- a/src/fedex_generator/Operations/Operation.py
+++ b/src/fedex_generator/Operations/Operation.py
@@ -1,4 +1,6 @@
 from typing import List
+import pandas as pd
+import numpy as np
 
 from fedex_generator.commons.consts import TOP_K_DEFAULT, DEFAULT_FIGS_IN_ROW
 
@@ -8,6 +10,8 @@ class Operation:
     An abstract class for operations within the FEDEx explainability framework.\n
     All implemented operations should inherit from this class.
     """
+
+    SAMPLE_SIZE = 5000
 
     def __init__(self, scheme: dict):
         """
@@ -31,7 +35,7 @@ class Operation:
 
     def explain(self, schema: dict = None, attributes: List[str] = None, top_k: int = TOP_K_DEFAULT,
                 figs_in_row: int = DEFAULT_FIGS_IN_ROW, show_scores: bool = False, title: str = None,
-                corr_TH: float = 0.7):
+                corr_TH: float = 0.7, use_sampling: bool = True):
         """
         Explain for operation
         :param schema: dictionary with new columns names, in case {'col_name': 'i'} will be ignored in the explanation
@@ -52,3 +56,16 @@ class Operation:
         :param figs_in_row: number of explanations figs in one row.
         """
         return NotImplementedError()
+
+    def sample(self, df: pd.DataFrame, sample_size: int = SAMPLE_SIZE) -> pd.DataFrame:
+        """
+        Uniformly sample the dataframe to the given sample size.
+        :param df: The dataframe to sample.
+        :param sample_size: The sample size to use. Default is SAMPLE_SIZE.
+        :return: The sampled dataframe.
+        """
+        if df.shape[0] <= sample_size:
+            return df
+        else:
+            uniform_indexes = np.random.choice(df.index, sample_size, replace=False)
+            return df.loc[uniform_indexes]

--- a/src/fedex_generator/Operations/Operation.py
+++ b/src/fedex_generator/Operations/Operation.py
@@ -70,7 +70,7 @@ class Operation:
         if sample_size <= 0:
             raise ValueError("Sample size must be a positive number.")
         if 0 < sample_size < 1:
-            sample_size = df.shape[0] * sample_size
+            sample_size = int(df.shape[0] * sample_size)
         # If the sample size is below the default sample size, we use the default sample size.
         # We do this because we know, from empirical testing, that our default size is a good balance between
         # performance and accuracy, and going below that size can lead to too big a loss in accuracy for

--- a/tests/extract_intermediate_results.py
+++ b/tests/extract_intermediate_results.py
@@ -54,7 +54,7 @@ class Query:
     column: str
     operation: str
     explainer: str
-    arguments: Dict[str, str | int | float]
+    arguments: Dict[str, str | int | float | bool]
 
     @staticmethod
     def from_string(s: str) -> 'Query':
@@ -125,6 +125,11 @@ def dict_string_to_dict(d: str) -> Dict[str, str | int | float]:
 
 
 def extract_global_select(select_str: str) -> List[str]:
+    """
+    Extract the global select operations (selects that are applied to the entire dataset across all queries) from the select string.
+    :param select_str: The select string.
+    :return: A list of global select operations.
+    """
     global_select = select_str.strip().replace('GlobalSelect=', '').replace('[', '').replace(']', '').split(',')
     for i in range(len(global_select)):
         global_select[i] = global_select[i].strip()
@@ -171,11 +176,12 @@ def create_operation_object(query: Query, dataset: DataFrame, second_dataset: Da
     :param second_dataset: The second dataset. Optional, and only needed for join operations.
     :return: an operation object, with the necessary parameters and the operation performed.
     """
+    use_sampling = query.arguments['use_sampling'] if 'use_sampling' in query.arguments else False
     if query.operation in operators:
         operation = Filter(
             source_df=dataset, source_scheme={},
             attribute=query.column, operation_str=query.operation,
-            value=query.arguments['value'])
+            value=query.arguments['value'], use_sampling=use_sampling)
     elif query.operation == 'groupby':
         if 'select_columns' not in query.arguments or query.arguments['select_columns'] is None:
             after_op = dataset.groupby(query.column).aggregate(query.arguments['agg_function'])
@@ -184,7 +190,7 @@ def create_operation_object(query: Query, dataset: DataFrame, second_dataset: Da
                 query.arguments['agg_function'])
         operation = GroupBy(
             source_df=dataset, source_scheme={}, agg_dict={},
-            group_attributes=[query.column], result_df=after_op
+            group_attributes=[query.column], result_df=after_op, use_sampling=use_sampling
         )
     elif query.operation == 'join':
         if second_dataset is None:
@@ -197,7 +203,7 @@ def create_operation_object(query: Query, dataset: DataFrame, second_dataset: Da
             second_dataset = second_dataset.head(1000)
         operation = Join(
             left_df=dataset, right_df=second_dataset, source_scheme={},
-            attribute=query.column
+            attribute=query.column, use_sampling=use_sampling
         )
     else:
         raise ValueError(f"Operation {query.operation} not supported.")

--- a/tests/extract_intermediate_results.py
+++ b/tests/extract_intermediate_results.py
@@ -176,12 +176,11 @@ def create_operation_object(query: Query, dataset: DataFrame, second_dataset: Da
     :param second_dataset: The second dataset. Optional, and only needed for join operations.
     :return: an operation object, with the necessary parameters and the operation performed.
     """
-    use_sampling = query.arguments['use_sampling'] if 'use_sampling' in query.arguments else False
     if query.operation in operators:
         operation = Filter(
             source_df=dataset, source_scheme={},
             attribute=query.column, operation_str=query.operation,
-            value=query.arguments['value'], use_sampling=use_sampling)
+            value=query.arguments['value'])
     elif query.operation == 'groupby':
         if 'select_columns' not in query.arguments or query.arguments['select_columns'] is None:
             after_op = dataset.groupby(query.column).aggregate(query.arguments['agg_function'])
@@ -190,7 +189,7 @@ def create_operation_object(query: Query, dataset: DataFrame, second_dataset: Da
                 query.arguments['agg_function'])
         operation = GroupBy(
             source_df=dataset, source_scheme={}, agg_dict={},
-            group_attributes=[query.column], result_df=after_op, use_sampling=use_sampling
+            group_attributes=[query.column], result_df=after_op
         )
     elif query.operation == 'join':
         if second_dataset is None:
@@ -203,7 +202,7 @@ def create_operation_object(query: Query, dataset: DataFrame, second_dataset: Da
             second_dataset = second_dataset.head(1000)
         operation = Join(
             left_df=dataset, right_df=second_dataset, source_scheme={},
-            attribute=query.column, use_sampling=use_sampling
+            attribute=query.column
         )
     else:
         raise ValueError(f"Operation {query.operation} not supported.")

--- a/tests/runtime_tests.py
+++ b/tests/runtime_tests.py
@@ -1,0 +1,63 @@
+"""
+A script for testing the runtime of running queries.
+This script expects 2 arguments: an array of paths to files containing the queries, and an array of paths to
+files containing the datasets. Both must be in the same order.
+This script only measures the overall execution time it takes to explain the queries, and not the time it takes
+to run each part of the explanation generation process.
+As such, it is recommended to run this script with a profiler to get a more detailed view of the runtime.
+"""
+
+from tests.extract_intermediate_results import get_queries, create_operation_object
+from tests.test_utils import load_dataset
+import time
+import argparse
+
+
+def main():
+    # We expect 2 arguments: an array of paths to files containing the queries, and an array of paths to
+    # files containing the datasets. Both must be in the same order.
+    parser = argparse.ArgumentParser(description='Test the runtime of the queries.')
+    parser.add_argument('--queries', type=str, nargs='+',
+                        help='Paths to files containing the queries')
+    parser.add_argument('--datasets', type=str, nargs='+',
+                        help='Paths to files containing the datasets')
+    args = parser.parse_args()
+    if len(args.queries) != len(args.datasets):
+        raise ValueError("The number of queries and datasets must be the same.")
+    if len(args.queries) == 0:
+        raise ValueError("No queries were provided.")
+    if len(args.datasets) == 0:
+        raise ValueError("No datasets were provided.")
+    runtimes = []
+    for i in range(len(args.queries)):
+        queries, global_select, _ = get_queries(args.queries[i])
+        dataset = load_dataset(args.datasets[i], "", [{}])
+        if global_select:
+            dataset = dataset[global_select]
+        for query in queries:
+            # We skip join operations, since allowing them here would make this way more complicated.
+            # They use mostly the same processes as the other operations, so we can safely assume their runtime
+            # is similar to the other operations.
+            # Outlier explainer is excluded because it used to be part of FEDEx_Generator, but was separated into
+            # its own module. This is simply an artifact to prevent errors in case anything is left over.
+            if query.operation == "join" or query.explainer == "outlier":
+                continue
+            operation = create_operation_object(query, dataset)
+            start_time = time.time()
+            operation.explain()
+            end_time = time.time()
+            print(f"Query {query} took {end_time - start_time} seconds to explain.")
+            runtimes.append(end_time - start_time)
+
+    print(f"Total time: {sum(runtimes)} seconds.")
+    print(f"Average time: {sum(runtimes) / len(runtimes)} seconds.")
+    print(f"Max time: {max(runtimes)} seconds.")
+    print(f"Min time: {min(runtimes)} seconds.")
+    print(f"Number of queries: {len(runtimes)}")
+
+
+
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
1. Fixed SettingOnCopyWarning that would be raised when calling explain on a filter operation.
2. Added multi-threading to computational bottlenecks in BaseMeasure and OutlierMeasure, resulting in a small speedup in explanation generation.
3. Added the sampling strategy from the FEDEX paper to all operations, resulting in a massive speedup in explanation generation, with only a minor hit to explanation quality, as they have demonstrated in the paper.
4. Fixed deprecation warning that would sometimes happen due to doing a concat with an empty dataframe.