### PR TITLE
Bug fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pandas
-numpy
-matplotlib
-scipy
-paretoset
+pandas>=2.2.3
+numpy>=2.1.3
+matplotlib>=3.9.0
+scipy>=1.14.1
+paretoset>=1.2.4

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def get_long_description():
 
 setup(
     name='fedex_generator',
-    version='1.0.4',#get_version(),
+    version='1.0.5',#get_version(),
     package_dir={'': 'src'},
     packages=find_packages(where='src'),
     long_description_content_type="text/markdown",
@@ -35,12 +35,10 @@ setup(
     },
     install_requires=[
         'wheel',
-        'pandas',
-        'numpy',
-        'python-dotenv',
-        'singleton-decorator',
-        'ipython',
-        'scipy',
-        'paretoset',
+        'pandas>=2.2.3',
+        'numpy>=2.1.3',
+        'matplotlib>=3.9.0',
+        'scipy>=1.14.1',
+        'paretoset>=1.2.4',
     ]
 )

--- a/src/fedex_generator/Measures/BaseMeasure.py
+++ b/src/fedex_generator/Measures/BaseMeasure.py
@@ -480,6 +480,9 @@ class BaseMeasure(object):
             print(f'Could not find any interesting explanations for your query over dataset {source_name}.')
             return
 
+        # Set the title of the plot to the title if it is not None, otherwise build the operation expression.
+        title = title if title else self.build_operation_expression(source_name)
+
         # If K is greater than 1,
         # set the number of rows in the plot to the ceiling of the length of the scores divided by figs_in_row.
         if K > 1:  ###
@@ -488,10 +491,15 @@ class BaseMeasure(object):
             for ax in axes.reshape(-1):
                 ax.set_axis_off()
         else:
-            fig, axes = plt.subplots(figsize=(5, 6))
-
-        # Set the title of the plot to the title if it is not None, otherwise build the operation expression.
-        title = title if title else self.build_operation_expression(source_name)
+            total_text_len = len(title) + len(explanations.iloc[0])
+            # If the text is so long that it probably won't fit properly in the figure, increase the figure size.
+            # Note that 300 is a fairly arbitrary threshold, made on an educated guess that the usual is around
+            # 150-250 characters long, and that 300+ is probably around where it starts to get too long.
+            if total_text_len > 300:
+                fig, axes = plt.subplots(figsize=(9, 11))
+            # Otherwise, use a smaller figure size.
+            else:
+                fig, axes = plt.subplots(figsize=(5, 6))
 
         fig.suptitle(title, fontsize=20)
 

--- a/src/fedex_generator/Measures/BaseMeasure.py
+++ b/src/fedex_generator/Measures/BaseMeasure.py
@@ -393,7 +393,7 @@ class BaseMeasure(object):
 
     def calc_influence(self, brute_force=False, top_k=TOP_K_DEFAULT,
                        figs_in_row: int = DEFAULT_FIGS_IN_ROW, show_scores: bool = False, title: str = None,
-                       deleted=None) -> matplotlib.pyplot.Figure | List[matplotlib.pyplot.Figure]:
+                       deleted=None) -> matplotlib.pyplot.Figure | List[matplotlib.pyplot.Figure] | List[str] | None:
         """
         Calculate the influence of each attribute in the dataset.
 
@@ -408,7 +408,7 @@ class BaseMeasure(object):
         :param deleted: A dictionary of deleted attributes as keys, with the values as a tuple: (dataframe name, bin object, score, column values). Optional.
 
         :return: A list (or a single) matplotlib figures containing the explanations for the top k attributes, after
-        computing the influence.
+        computing the influence. Alternatively, returns the names of the explained attributes, or None if no explanations were found.
         """
 
         # If deleted is not None, set the score dictionary to the deleted dictionary.
@@ -464,7 +464,7 @@ class BaseMeasure(object):
 
         # If there are no interesting explanations, print a message and return.
         if len(scores) == 0:
-            print(f'Could not find any interesting explanations for dataset {source_name}.')
+            print(f'Could not find any interesting explanations for your query over dataset {source_name}.')
             return
 
         # If K is greater than 1,

--- a/src/fedex_generator/Measures/BaseMeasure.py
+++ b/src/fedex_generator/Measures/BaseMeasure.py
@@ -461,23 +461,23 @@ class BaseMeasure(object):
 
         # If there are no interesting explanations, print a message and return.
         if len(scores) == 0:
-            print(f'{source_name} dataset there is not interesting explanation')
+            print(f'Could not find any interesting explanations for dataset {source_name}.')
             return
 
         # If K is greater than 1,
         # set the number of rows in the plot to the ceiling of the length of the scores divided by figs_in_row.
         if K > 1:  ###
             rows = math.ceil(len(scores) / figs_in_row)
-            fig, axes = plt.subplots(rows, figs_in_row, figsize=(5 * figs_in_row, 6 * rows))
+            fig, axes = plt.subplots(rows, figs_in_row, figsize=(7 * figs_in_row, 8 * rows))
             for ax in axes.reshape(-1):
                 ax.set_axis_off()
         else:
-            fig, axes = plt.subplots(figsize=(5, 5))
+            fig, axes = plt.subplots(figsize=(7, 8))
 
         # Set the title of the plot to the title if it is not None, otherwise build the operation expression.
         title = title if title else self.build_operation_expression(source_name)
 
-        fig.suptitle(title, fontsize=20)
+        fig.suptitle(title, fontsize=30)
 
         # Draw the bar plots for each explanation
         for index, (explanation, current_bin, current_influence_vals, score) in enumerate(

--- a/src/fedex_generator/Measures/BaseMeasure.py
+++ b/src/fedex_generator/Measures/BaseMeasure.py
@@ -475,12 +475,12 @@ class BaseMeasure(object):
             for ax in axes.reshape(-1):
                 ax.set_axis_off()
         else:
-            fig, axes = plt.subplots(figsize=(7, 8))
+            fig, axes = plt.subplots(figsize=(5, 6))
 
         # Set the title of the plot to the title if it is not None, otherwise build the operation expression.
         title = title if title else self.build_operation_expression(source_name)
 
-        fig.suptitle(title, fontsize=30)
+        fig.suptitle(title, fontsize=20)
 
         # Draw the bar plots for each explanation
         for index, (explanation, current_bin, current_influence_vals, score) in enumerate(

--- a/src/fedex_generator/Measures/BaseMeasure.py
+++ b/src/fedex_generator/Measures/BaseMeasure.py
@@ -167,12 +167,15 @@ class BaseMeasure(object):
         unsampled_bin_candidates = None
 
         if unsampled_source_df is not None and unsampled_res_df is not None:
-            # In the case of groupby that creates tuple columns, we need to handle the case where the attribute in the
-            # result dataframe is a tuple that did not exist in the source dataframe.
-            if attr not in unsampled_source_df.columns and isinstance(attr, tuple):
-                source_col = unsampled_source_df[attr[0]]
-            else:
-                source_col = unsampled_source_df[attr] if attr not in column_mapping else unsampled_source_df[column_mapping[attr]]
+            # source_col can be none in some groupby cases. We don't want to modify it if it is, as that may cause
+            # unexpected behavior.
+            if source_col is not None:
+                # In the case of groupby that creates tuple columns, we need to handle the case where the attribute in the
+                # result dataframe is a tuple that did not exist in the source dataframe.
+                if attr not in unsampled_source_df.columns and isinstance(attr, tuple):
+                    source_col = unsampled_source_df[attr[0]]
+                else:
+                    source_col = unsampled_source_df[attr] if attr not in column_mapping else unsampled_source_df[column_mapping[attr]]
             res_col = unsampled_res_df[attr]
             unsampled_bin_candidates = Bins(source_col, res_col, size)
 

--- a/src/fedex_generator/Measures/BaseMeasure.py
+++ b/src/fedex_generator/Measures/BaseMeasure.py
@@ -491,7 +491,11 @@ class BaseMeasure(object):
             for ax in axes.reshape(-1):
                 ax.set_axis_off()
         else:
-            total_text_len = len(title) + len(explanations.iloc[0])
+            total_text_len = 0
+            if title:
+                total_text_len += len(title)
+            if explanations is not None and len(explanations) > 0:
+                total_text_len += len(explanations.iloc[0])
             # If the text is so long that it probably won't fit properly in the figure, increase the figure size.
             # Note that 300 is a fairly arbitrary threshold, made on an educated guess that the usual is around
             # 150-250 characters long, and that 300+ is probably around where it starts to get too long.

--- a/src/fedex_generator/Measures/DiversityMeasure.py
+++ b/src/fedex_generator/Measures/DiversityMeasure.py
@@ -140,7 +140,13 @@ class DiversityMeasure(BaseMeasure):
         """
 
         # Check if the name corresponds to a method of `pd.Series` or is in the `OP_TO_FUNC` dictionary
-        operation = name.split("_")[-1].lower()
+        if isinstance(name, str):
+            operation = name.split("_")[-1].lower()
+        elif isinstance(name, tuple):
+            name = "_".join(x for x in name)
+            operation = name.lower()
+        else:
+            raise TypeError(f"The type of the column name is {type(name)}, which we the developers did not expect and do not know how to handle. If you are a developer, please fix this. If you are a user, please report this. Thank you.")
         if hasattr(pd.Series, operation):
             return getattr(pd.Series, operation)
         elif operation in OP_TO_FUNC:
@@ -243,7 +249,8 @@ class DiversityMeasure(BaseMeasure):
         :return: new explanation
         """
         max_group_value = list(binned_column[binned_column == max_value].to_dict().keys())[0]
-        max_value_name = binned_column.name.replace('_', '\\ ')
+        binned_column_name = str(binned_column.name)
+        max_value_name = binned_column_name.replace('_', '\\ ')
         try:
             max_group_value.replace('$', '\\$')
             max_value_name.replace('$', '\\$')

--- a/src/fedex_generator/Measures/DiversityMeasure.py
+++ b/src/fedex_generator/Measures/DiversityMeasure.py
@@ -306,13 +306,14 @@ class DiversityMeasure(BaseMeasure):
                 columns = columns.loc[indexes]
                 columns = columns[:self.MAX_BARS]
 
-            # The only way I can see this happening is there are so many columns with the max value that the max
-            # value is not in the columns, though it still shouldn't happen because we choose the 1st in the beginning.
-            # Regardless, just to be safe, we'll add the max value to the columns if it's not there.
+            # If the max value is not in the columns, add it to the columns
             if not isinstance(max_group_value, list):
                 if max_group_value not in columns:
                     columns = columns.append(pd.Series(max_value, index=[max_group_value]))
             else:
+                # Not having the index sorted can raise a performance warning, so we sort it if it's not sorted
+                if not columns.index._is_lexsorted():
+                    columns = columns.sort_index()
                 for value in max_group_value:
                     if value not in columns:
                         columns = columns.append(pd.Series(max_value, index=[value]))

--- a/src/fedex_generator/Measures/ExceptionalityMeasure.py
+++ b/src/fedex_generator/Measures/ExceptionalityMeasure.py
@@ -94,9 +94,9 @@ class ExceptionalityMeasure(BaseMeasure):
         # Set the title of the bar chart. If show_scores is True, display the score in the title
         if title is not None:
             if show_scores:
-                ax.set_title(f'score: {score}\n {utils.to_valid_latex(title)}', fontdict={'fontsize': 14})
+                ax.set_title(f'score: {score}\n {utils.to_valid_latex(title)}', fontdict={'fontsize': 20})
             else:
-                ax.set_title(utils.to_valid_latex(title), fontdict={'fontsize': 14})
+                ax.set_title(utils.to_valid_latex(title), fontdict={'fontsize': 20})
 
         ax.set_axis_on()
         return bin_item.get_bin_name()  ####

--- a/src/fedex_generator/Operations/Filter.py
+++ b/src/fedex_generator/Operations/Filter.py
@@ -121,8 +121,8 @@ class Filter(Operation.Operation):
         high_correlated_columns = self.get_correlated_attributes()
 
         for attr in self.result_df.columns:
-            if attr.lower() == "index" or attr.lower() == self.attribute.lower() or \
-                    self.source_scheme.get(attr, None) == 'i' or attr in high_correlated_columns:
+            if isinstance(attr, str) and (attr.lower() == "index" or attr.lower() == self.attribute.lower() or \
+                    self.source_scheme.get(attr, None) == 'i' or attr in high_correlated_columns):
                 continue
             yield attr, DatasetRelation(self.source_df, self.result_df, self.source_name)
 

--- a/src/fedex_generator/Operations/Filter.py
+++ b/src/fedex_generator/Operations/Filter.py
@@ -209,6 +209,9 @@ class Filter(Operation.Operation):
 
         :param figs_in_row: The number of figures to display in one row. Default is the value of DEFAULT_FIGS_IN_ROW.
         """
+        if len(self.not_presented) == 0:
+            print("No attributes were deleted due to high correlation.")
+            return
         measure = ExceptionalityMeasure()
         measure.calc_influence(deleted=self.not_presented, figs_in_row=figs_in_row)
 

--- a/src/fedex_generator/Operations/Filter.py
+++ b/src/fedex_generator/Operations/Filter.py
@@ -149,7 +149,7 @@ class Filter(Operation.Operation):
     def explain(self, schema=None, attributes=None, top_k=TOP_K_DEFAULT,
                 figs_in_row: int = DEFAULT_FIGS_IN_ROW, show_scores: bool = False, title: str = None,
                 corr_TH: float = 0.7, explainer='fedex', consider='right', cont=None, attr=None, ignore=[],
-                use_sampling: bool = True, sample_size = Operation.SAMPLE_SIZE) -> None:
+                use_sampling: bool = True, sample_size = Operation.SAMPLE_SIZE, debug_mode: bool =False) -> None:
         """
         Explain for filter operation
 
@@ -167,6 +167,7 @@ class Filter(Operation.Operation):
         :param ignore: Unused but kept for compatibility.
         :param use_sampling: Whether to use sampling to speed up the generation of explanations.
         :param sample_size: The sample size to use when using sampling. Can be a number or a percentage of the dataframe size. Default is 5000.
+        :param debug_mode: Developer option for debugging. Disables multiprocessing when enabled. Can also be used to print additional information. Default is False.
 
         :return: explain figures
         """
@@ -184,12 +185,13 @@ class Filter(Operation.Operation):
 
         # The measure used for filer operations is always the ExceptionalityMeasure.
         measure = ExceptionalityMeasure()
-        scores = measure.calc_measure(self, schema, attributes, unsampled_source_df=source_df_backup, unsampled_res_df=result_df_backup)
+        scores = measure.calc_measure(self, schema, attributes, unsampled_source_df=source_df_backup,
+                                      unsampled_res_df=result_df_backup, debug_mode=debug_mode)
 
         self.delete_correlated_atts(measure, TH=corr_TH)
         # Get the explanation figures.
         figures = measure.calc_influence(utils.max_key(scores), top_k=top_k, figs_in_row=figs_in_row,
-                                         show_scores=show_scores, title=title)
+                                         show_scores=show_scores, title=title, debug_mode=debug_mode)
         if figures:
             self.correlated_notes(figures, top_k)
 

--- a/src/fedex_generator/Operations/GroupBy.py
+++ b/src/fedex_generator/Operations/GroupBy.py
@@ -94,7 +94,7 @@ class GroupBy(Operation.Operation):
         backup_source_df, backup_res_df = None, None
         if use_sampling:
             backup_source_df, backup_res_df = self.source_df, self.result_df
-            self.source_df, self.result_df = self.sample(self.source_df), self.sample(self.result_df)
+            self.source_df, self.result_df = self.sample(self.source_df, sample_size), self.sample(self.result_df, sample_size)
 
         # Unless the outlier explainer is used, the diversity measure is always used for the groupby operation.
         measure = DiversityMeasure()

--- a/src/fedex_generator/Operations/GroupBy.py
+++ b/src/fedex_generator/Operations/GroupBy.py
@@ -17,7 +17,7 @@ class GroupBy(Operation.Operation):
     """
 
     def __init__(self, source_df, source_scheme, group_attributes, agg_dict, result_df=None, source_name=None,
-                 operation=None):
+                 operation=None, column_mapping=None):
         """
         :param source_df: The source DataFrame, before the groupby operation.
         :param source_scheme: The scheme of the source DataFrame.
@@ -46,6 +46,8 @@ class GroupBy(Operation.Operation):
             self.result_df = result_df
             self.result_name = utils.get_calling_params_name(result_df)
 
+        self._column_mapping = column_mapping
+
 
     def iterate_attributes(self) -> Generator[Tuple[str, DatasetRelation], None, None]:
         """
@@ -57,7 +59,7 @@ class GroupBy(Operation.Operation):
         :yield: A tuple containing the attribute name and a DatasetRelation object.
         """
         for attr in self.result_df.columns:
-            if attr.lower() == "index":
+            if isinstance(attr, str) and attr.lower() == "index":
                 continue
             yield attr, DatasetRelation(None, self.result_df, self.source_name)
 
@@ -97,7 +99,7 @@ class GroupBy(Operation.Operation):
         # Unless the outlier explainer is used, the diversity measure is always used for the groupby operation.
         measure = DiversityMeasure()
         scores = measure.calc_measure(self, schema, attributes, ignore=ignore, unsampled_source_df=backup_source_df,
-                                      unsampled_res_df=backup_res_df)
+                                      unsampled_res_df=backup_res_df, column_mapping=self._column_mapping)
         figures = measure.calc_influence(utils.max_key(scores), top_k=top_k, figs_in_row=figs_in_row,
                                          show_scores=show_scores, title=title)
 

--- a/src/fedex_generator/Operations/GroupBy.py
+++ b/src/fedex_generator/Operations/GroupBy.py
@@ -26,6 +26,7 @@ class GroupBy(Operation.Operation):
         :param result_df: The resulting DataFrame after the groupby operation.
         :param source_name: The name of the source DataFrame.
         :param operation: The operation to perform.
+        :param column_mapping: A possible mapping between the source and result columns, if changes were made.
         """
         super().__init__(source_scheme)
         # Set the attributes
@@ -69,7 +70,9 @@ class GroupBy(Operation.Operation):
     def explain(self, schema: dict=None, attributes: List[str]=None, top_k: int=TOP_K_DEFAULT, explainer: str='fedex',
                 figs_in_row: int = DEFAULT_FIGS_IN_ROW, show_scores: bool = False, title: str = None,
                 corr_TH: float = 0.7, consider='right', cont=None, attr=None, ignore=[],
-                use_sampling=True, sample_size: int | float = Operation.SAMPLE_SIZE):
+                use_sampling=True, sample_size: int | float = Operation.SAMPLE_SIZE,
+                debug_mode: bool = False
+                ):
         """
         Explain for group by operation
         :param schema: dictionary with new columns names, in case {'col_name': 'i'} will be ignored in the explanation
@@ -81,6 +84,7 @@ class GroupBy(Operation.Operation):
         :param dir: direction of the outlier. Can be 'high' or 'low', or the corresponding integer values 1 and -1 (HIGH and LOW constants).
         :param use_sampling: whether to use sampling for the explanation.
         :param sample_size: the sample size to use when sampling the data. Can be an integer or a float between 0 and 1. Default is 5000.
+        :param debug_mode: Developer option. Disables multiprocessing for easier debugging. Default is False. Can possibly add more debug options in the future.
 
         :return: explain figures
         """
@@ -99,9 +103,9 @@ class GroupBy(Operation.Operation):
         # Unless the outlier explainer is used, the diversity measure is always used for the groupby operation.
         measure = DiversityMeasure()
         scores = measure.calc_measure(self, schema, attributes, ignore=ignore, unsampled_source_df=backup_source_df,
-                                      unsampled_res_df=backup_res_df, column_mapping=self._column_mapping)
+                                      unsampled_res_df=backup_res_df, column_mapping=self._column_mapping, debug_mode=debug_mode)
         figures = measure.calc_influence(utils.max_key(scores), top_k=top_k, figs_in_row=figs_in_row,
-                                         show_scores=show_scores, title=title)
+                                         show_scores=show_scores, title=title, debug_mode=debug_mode)
 
         if use_sampling:
             self.source_df, self.result_df = backup_source_df, backup_res_df

--- a/src/fedex_generator/Operations/Join.py
+++ b/src/fedex_generator/Operations/Join.py
@@ -60,12 +60,12 @@ class Join(Operation.Operation):
         :yield: Tuples of attribute name and DatasetRelation objects with the left and right DataFrames and the result DataFrame.
         """
         for attr in self.left_df.columns:
-            if attr.lower() == "index":
+            if isinstance(attr, str) and attr.lower() == "index":
                 continue
             yield attr, DatasetRelation(self.left_df, self.result_df, self.left_name)
 
         for attr in set(self.right_df.columns) - set(self.left_df.columns):
-            if attr.lower() == "index":
+            if isinstance(attr, str) and attr.lower() == "index":
                 continue
             yield attr, DatasetRelation(self.right_df, self.result_df, self.right_name)
 

--- a/src/fedex_generator/Operations/Join.py
+++ b/src/fedex_generator/Operations/Join.py
@@ -72,7 +72,9 @@ class Join(Operation.Operation):
     def explain(self, schema: dict=None, attributes: List[str]=None, top_k: int=TOP_K_DEFAULT,
                 figs_in_row: int = DEFAULT_FIGS_IN_ROW, show_scores: bool = False, title: str = None,
                 corr_TH: float = 0.7, explainer='fedex', consider='right', cont=None, attr=None, ignore=[],
-                use_sampling: bool = True, sample_size: int | float = Operation.SAMPLE_SIZE):
+                use_sampling: bool = True, sample_size: int | float = Operation.SAMPLE_SIZE,
+                debug_mode: bool = False
+                ):
         """
         Explain for filter operation
 
@@ -84,6 +86,7 @@ class Join(Operation.Operation):
         :param title: explanation title
         :param use_sampling: whether to use sampling or not
         :param sample_size: the size of the sample to use. Can be a percentage of the dataframe size if below 1. Default is 5000.
+        :param debug_mode: Developer option. Disables multiprocessing for easier debugging. Default is False. Can possibly add more debug options in the future.
 
         :return: explain figures
         """
@@ -120,10 +123,11 @@ class Join(Operation.Operation):
 
         # When using the FEDEx explainer, the exceptionality measure is used to calculate the explanation.
         measure = ExceptionalityMeasure()
-        scores = measure.calc_measure(self, schema, attributes, unsampled_source_df=combined_source_df, unsampled_res_df=backup_res_df)
+        scores = measure.calc_measure(self, schema, attributes, unsampled_source_df=combined_source_df,
+                                      unsampled_res_df=backup_res_df, debug_mode=debug_mode)
 
         figures = measure.calc_influence(utils.max_key(scores), top_k=top_k, figs_in_row=figs_in_row,
-                                         show_scores=show_scores, title=title)
+                                         show_scores=show_scores, title=title, debug_mode=debug_mode)
 
         if use_sampling:
             self.left_df, self.right_df, self.result_df = backup_left_df, backup_right_df, backup_res_df

--- a/src/fedex_generator/Operations/Operation.py
+++ b/src/fedex_generator/Operations/Operation.py
@@ -77,9 +77,12 @@ class Operation:
         # a very small gain in performance.
         if sample_size < SAMPLE_SIZE:
             sample_size = SAMPLE_SIZE
+        # If the sample size is larger than the dataframe, we return the dataframe as is
         if df.shape[0] <= sample_size:
             return df
         else:
+            # Convert the sample size to an integer, in case it was passed as a float above 1.
+            sample_size = int(sample_size)
             # We use a set seed so that the user will always get the same explanation when using sampling.
             generator = np.random.default_rng(RANDOM_SEED)
             uniform_indexes = generator.choice(df.index, sample_size, replace=False)


### PR DESCRIPTION
Fixed the following bugs:

- An error in all operations where if an attribute's name was not a string (for example, tuple or int), an exception would be thrown.
- Calling explain on a multi-index groupby with sampling enabled would cause an exception when trying to access the column in the unsampled dataframe.
- Calling explain on a multi-index groupby could sometimes lead to it not being able to find the operation name, causing an error.
- GroupBy explanations could include more than the specified 25 labels if it reaches the except block, potentially making plots unreadable.
- Users could pass a float to the sample function without it being converted to int.
- Sample_size parameter was not passed to sample function in GroupBy.
- Calling explain on a groupby with sampling enabled could cause the sampling to change the usual behavior by setting the source_col, when the source_col was None.
- Creating a plot for an explanation of a multi-index groupby could cause a crash, if the max_value was a string and not a tuple (i.e. one attribute of the multi-index and not a full line of the multi-index).
- DiversityMeasure's get_agg_func_from_name could return an incorrect function if a column name coincides with a pd.series function.
- DiverysityMeasure's get_agg_func_from_name would not find agg attribute name when aggregation was done on all columns.
- A string could be used as a callable (and thus cause an exception) when retrieving the agg function from get_agg_func_from_name for multi-index groupbys.
- DiversityMeasure's get_agg_func_from_name used string functions when its input could also be a number or a tuple, leading to exceptions.
- Aggregation function 'nunique' was missing from GroupBy's OP_TO_FUNC dict.
- DiversityMeasure's get_agg_func_from_name could return a property instead of a string or callable if the name coincided with a series property.
- Filter's present_deleted_correlated could throw a non-informative error if there were no deleted attributes when called.
- Figures with too much text would turn incomprehensible and also break plt's tight_layout (and cause a warning to be raised). Added a condition which increases figure size if there is too much text to solve it.


Other changes:

- Slightly increased overall figure size, to account for longer text (which would "squish" the graph itself), without making it too large.
- Changed some of the returned text to be more grammatically correct.
- Edited some documentation to be clearer.
- Added "debug_mode" to explain function, which enabled turning off multi-threading for easier debugging when needed.
- Added minimum versions to all installs in setup.py and requirements.txt
- Removed unused packages from requirements in setup.py.