### PR TITLE
Pd-explain LLM integration adjustments and bug fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def get_long_description():
 
 setup(
     name='fedex_generator',
-    version='1.0.5',#get_version(),
+    version='1.0.6',#get_version(),
     package_dir={'': 'src'},
     packages=find_packages(where='src'),
     long_description_content_type="text/markdown",

--- a/src/fedex_generator/Measures/BaseMeasure.py
+++ b/src/fedex_generator/Measures/BaseMeasure.py
@@ -470,8 +470,6 @@ class BaseMeasure(object):
             if figure:
                 figures.append(figure)
 
-        plt.tight_layout()
-
         if added_text is not None:
             # Draw the figure to establish precise bounding boxes
             plt.draw()
@@ -522,6 +520,7 @@ class BaseMeasure(object):
             plt.subplots_adjust(hspace=1.5)
         # Adding a bit of a top margin to the plot, to make sure the title doesn't interfere with the plots.
         plt.subplots_adjust(top=0.92)
+        plt.tight_layout()
 
         return figures if len(figures) > 0 else figure
 

--- a/src/fedex_generator/Measures/BaseMeasure.py
+++ b/src/fedex_generator/Measures/BaseMeasure.py
@@ -458,7 +458,7 @@ class BaseMeasure(object):
             else:
                 fig, axes = plt.subplots(figsize=(5, 6))
 
-        fig.suptitle(title, fontsize=20)
+        fig.suptitle(title, fontsize=20, y=1.02)
 
         # Draw the bar plots for each explanation
         for index, (explanation, current_bin, current_influence_vals, score) in enumerate(

--- a/src/fedex_generator/Measures/BaseMeasure.py
+++ b/src/fedex_generator/Measures/BaseMeasure.py
@@ -488,20 +488,34 @@ class BaseMeasure(object):
 
 
                 # Add a little bit of padding
-                offset_in_points = -(max_label_height + 10)
-                llm_explanation = added_text[explanation]
-                llm_text = llm_explanation["added_text"]
-                llm_position = llm_explanation["position"]
+                added_text_dict = added_text[explanation]
+                text = added_text_dict["added_text"]
+                position = added_text_dict["position"]
 
-                ax.annotate(
-                    llm_text,
-                    xy=(0.5, 0),  # anchor at the bottom of the axes
-                    xycoords='axes fraction',
-                    xytext=(0, offset_in_points),
-                    textcoords='offset points',
-                    ha='center', va='top',
-                    fontsize=16
-                )
+                if position == "bottom":
+                    offset_in_points = -(max_label_height + 10)
+
+                    ax.annotate(
+                        text,
+                        xy=(0.5, 0),  # anchor at the bottom of the axes
+                        xycoords='axes fraction',
+                        xytext=(0, offset_in_points),
+                        textcoords='offset points',
+                        ha='center', va='top',
+                        fontsize=16
+                    )
+                elif position == "top":
+                    offset_in_points = max_label_height + 10
+
+                    ax.annotate(
+                        text,
+                        xy=(0.5, 1),  # anchor at the top of the axes
+                        xycoords='axes fraction',
+                        xytext=(0, offset_in_points),
+                        textcoords='offset points',
+                        ha='center', va='bottom',
+                        fontsize=16
+                    )
 
             # Adding hspace of 1.5 seems to generally give enough space for the added text, without
             # squishing the plots too much or leaving too much empty space.

--- a/src/fedex_generator/Measures/DiversityMeasure.py
+++ b/src/fedex_generator/Measures/DiversityMeasure.py
@@ -29,7 +29,7 @@ OP_TO_FUNC = {
 
 
 def draw_bar(x: list, y: list, avg_line=None, items_to_bold=None, head_values=None, xname=None, yname=None, alpha=1.,
-             ax=None, added_text: dict | None = None):
+             ax=None):
     """
     Draw a bar chart with optional features.
 
@@ -42,7 +42,6 @@ def draw_bar(x: list, y: list, avg_line=None, items_to_bold=None, head_values=No
     :param yname: Optional; label for the y-axis.
     :param alpha: Optional; transparency level of the bars (default is 1.0).
     :param ax: Optional; matplotlib axes object to draw the bar chart on.
-    :param added_text: Optional; additional text to add to the plot. Expected format is a dictionary with the following keys: 'added_text', 'position'.
     """
 
     width = 0.5
@@ -84,14 +83,6 @@ def draw_bar(x: list, y: list, avg_line=None, items_to_bold=None, head_values=No
 
     if yname is not None:
         ax.set_ylabel(utils.to_valid_latex_with_escaped_dollar_char(yname), fontsize=24)
-
-    if added_text is not None:
-        text = added_text['added_text']
-        position = added_text['position']
-        if position == 'bottom':
-            ax.text(0, -0.2, text, fontsize=10, transform=ax.transAxes)
-        elif position == 'top':
-            ax.text(0, 1.1, text, fontsize=10, transform=ax.transAxes)
 
 
 def flatten_other_indexes(series, main_index):
@@ -163,7 +154,8 @@ class DiversityMeasure(BaseMeasure):
             name = "_".join(x for x in name)
             operation = name.lower()
         else:
-            raise TypeError(f"The type of the column name is {type(name)}, which we the developers did not expect and do not know how to handle. If you are a developer, please fix this. If you are a user, please report this. Thank you.")
+            raise TypeError(
+                f"The type of the column name is {type(name)}, which we the developers did not expect and do not know how to handle. If you are a developer, please fix this. If you are a user, please report this. Thank you.")
 
         # Check if the name corresponds to a method of `pd.Series` or is in the `OP_TO_FUNC` dictionary
         # If the operation is a method of `pd.Series`, we can quickly return the function. Unless the operation name coincides with a column name,
@@ -200,9 +192,8 @@ class DiversityMeasure(BaseMeasure):
         # aggregation_index = res.index(name)
         # return list(self.operation_object.agg_dict.values())[0][aggregation_index]
 
-
     def draw_bar(self, bin_item: MultiIndexBin, influence_vals: dict = None, title=None, ax=None, score=None,
-                 show_scores: bool = False, added_text: dict | None = None):
+                 show_scores: bool = False):
         """
         Draw a bar chart for a given bin item with optional features.
 
@@ -215,7 +206,6 @@ class DiversityMeasure(BaseMeasure):
         :param ax: Optional; the matplotlib axes object to draw the bar chart on.
         :param score: Optional; the score to be displayed in the title if `show_scores` is True.
         :param show_scores: Optional; a boolean indicating whether to display the score in the title (default is False).
-        :param added_text: Optional; additional text to add to the plot. Expected format is a dictionary with the following keys: 'added_text', 'position'.
         """
         try:
             # Get the index of the maximum value and its influence
@@ -262,7 +252,7 @@ class DiversityMeasure(BaseMeasure):
 
             draw_bar(labels, aggregate_column, aggregated_result.mean(), [max_value],
                      xname=f'{bin_item.get_bin_name()} values', yname=bin_item.get_value_name(),
-                     ax=ax, added_text=added_text)
+                     ax=ax)
             ax.set_axis_on()
 
         except Exception as e:
@@ -338,7 +328,6 @@ class DiversityMeasure(BaseMeasure):
                      [max_group_value] if not isinstance(max_group_value, list) else max_group_value,
                      yname=bin_item.get_bin_name(),
                      ax=ax,
-                     added_text=added_text
                      )
 
             ax.set_axis_on()

--- a/src/fedex_generator/Measures/DiversityMeasure.py
+++ b/src/fedex_generator/Measures/DiversityMeasure.py
@@ -189,7 +189,7 @@ class DiversityMeasure(BaseMeasure):
         try:
             aggregation_index = res.index(name)
             return list(self.operation_object.agg_dict.values())[0][aggregation_index]
-        except ValueError as e:
+        except (ValueError, IndexError) as e:
             if any([x.startswith("All_") for x in res]):
                 return list(self.operation_object.agg_dict.values())[0][0]
             # It is also possible that we get names that don't include the aggregation function, but are still

--- a/src/fedex_generator/Measures/DiversityMeasure.py
+++ b/src/fedex_generator/Measures/DiversityMeasure.py
@@ -29,7 +29,7 @@ OP_TO_FUNC = {
 
 
 def draw_bar(x: list, y: list, avg_line=None, items_to_bold=None, head_values=None, xname=None, yname=None, alpha=1.,
-             ax=None, footnote: str = None):
+             ax=None, added_text: dict | None = None):
     """
     Draw a bar chart with optional features.
 
@@ -42,6 +42,7 @@ def draw_bar(x: list, y: list, avg_line=None, items_to_bold=None, head_values=No
     :param yname: Optional; label for the y-axis.
     :param alpha: Optional; transparency level of the bars (default is 1.0).
     :param ax: Optional; matplotlib axes object to draw the bar chart on.
+    :param added_text: Optional; additional text to add to the plot. Expected format is a dictionary with the following keys: 'added_text', 'position'.
     """
 
     width = 0.5
@@ -83,6 +84,14 @@ def draw_bar(x: list, y: list, avg_line=None, items_to_bold=None, head_values=No
 
     if yname is not None:
         ax.set_ylabel(utils.to_valid_latex_with_escaped_dollar_char(yname), fontsize=24)
+
+    if added_text is not None:
+        text = added_text['added_text']
+        position = added_text['position']
+        if position == 'bottom':
+            ax.text(0, -0.2, text, fontsize=10, transform=ax.transAxes)
+        elif position == 'top':
+            ax.text(0, 1.1, text, fontsize=10, transform=ax.transAxes)
 
 
 def flatten_other_indexes(series, main_index):
@@ -193,7 +202,7 @@ class DiversityMeasure(BaseMeasure):
 
 
     def draw_bar(self, bin_item: MultiIndexBin, influence_vals: dict = None, title=None, ax=None, score=None,
-                 show_scores: bool = False):
+                 show_scores: bool = False, added_text: dict | None = None):
         """
         Draw a bar chart for a given bin item with optional features.
 
@@ -206,6 +215,7 @@ class DiversityMeasure(BaseMeasure):
         :param ax: Optional; the matplotlib axes object to draw the bar chart on.
         :param score: Optional; the score to be displayed in the title if `show_scores` is True.
         :param show_scores: Optional; a boolean indicating whether to display the score in the title (default is False).
+        :param added_text: Optional; additional text to add to the plot. Expected format is a dictionary with the following keys: 'added_text', 'position'.
         """
         try:
             # Get the index of the maximum value and its influence
@@ -251,7 +261,8 @@ class DiversityMeasure(BaseMeasure):
                 ax.set_title(utils.to_valid_latex(title), fontdict={'fontsize': 20})
 
             draw_bar(labels, aggregate_column, aggregated_result.mean(), [max_value],
-                     xname=f'{bin_item.get_bin_name()} values', yname=bin_item.get_value_name(), ax=ax)
+                     xname=f'{bin_item.get_bin_name()} values', yname=bin_item.get_value_name(),
+                     ax=ax, added_text=added_text)
             ax.set_axis_on()
 
         except Exception as e:
@@ -325,7 +336,10 @@ class DiversityMeasure(BaseMeasure):
                      list(columns),
                      average,
                      [max_group_value] if not isinstance(max_group_value, list) else max_group_value,
-                     yname=bin_item.get_bin_name(), ax=ax)
+                     yname=bin_item.get_bin_name(),
+                     ax=ax,
+                     added_text=added_text
+                     )
 
             ax.set_axis_on()
 

--- a/src/fedex_generator/Measures/ExceptionalityMeasure.py
+++ b/src/fedex_generator/Measures/ExceptionalityMeasure.py
@@ -33,7 +33,7 @@ class ExceptionalityMeasure(BaseMeasure):
         super().__init__()
 
     def draw_bar(self, bin_item: Bin, influence_vals: dict = None, title=None, ax=None, score=None,
-                 show_scores: bool = False) -> str:
+                 show_scores: bool = False, added_text: dict | None = None) -> str:
         """
         Draw a bar chart comparing the distribution of values before and after an operation.
 
@@ -46,6 +46,7 @@ class ExceptionalityMeasure(BaseMeasure):
         :param ax: The matplotlib axes object to draw the bar chart on (default is None).
         :param score: The score to be displayed in the title if show_scores is True (default is None).
         :param show_scores: A boolean indicating whether to display the score in the title (default is False).
+        :param added_text: A dictionary containing additional text to be displayed in the explanation (default is None). Expected keys are 'added_text' and 'position'.
 
         :return: The name of the bin.
         """
@@ -170,8 +171,13 @@ class ExceptionalityMeasure(BaseMeasure):
         from fedex_generator.Operations.Join import Join
 
         if isinstance(self.operation_object, Filter):
-            return f'Dataframe {self.operation_object.source_name}, ' \
-                   f'filtered on attribute {self.operation_object.attribute}'
+            if self.operation_object.value is not None and self.operation_object.operation_str is not None:
+                return f'Dataframe {self.operation_object.source_name}, ' \
+                       f'filtered on attribute {self.operation_object.attribute} ' \
+                       f'{self.operation_object.operation_str} {self.operation_object.value}'
+            else:
+                return f'Dataframe {self.operation_object.source_name}, ' \
+                       f'filtered on attribute {self.operation_object.attribute}'
         elif isinstance(self.operation_object, Join):
             return f'{self.operation_object.right_name} joined with {self.operation_object.left_name} by {self.operation_object.attribute}'
 

--- a/src/fedex_generator/Measures/ExceptionalityMeasure.py
+++ b/src/fedex_generator/Measures/ExceptionalityMeasure.py
@@ -33,7 +33,7 @@ class ExceptionalityMeasure(BaseMeasure):
         super().__init__()
 
     def draw_bar(self, bin_item: Bin, influence_vals: dict = None, title=None, ax=None, score=None,
-                 show_scores: bool = False, added_text: dict | None = None) -> str:
+                 show_scores: bool = False) -> str:
         """
         Draw a bar chart comparing the distribution of values before and after an operation.
 
@@ -46,7 +46,6 @@ class ExceptionalityMeasure(BaseMeasure):
         :param ax: The matplotlib axes object to draw the bar chart on (default is None).
         :param score: The score to be displayed in the title if show_scores is True (default is None).
         :param show_scores: A boolean indicating whether to display the score in the title (default is False).
-        :param added_text: A dictionary containing additional text to be displayed in the explanation (default is None). Expected keys are 'added_text' and 'position'.
 
         :return: The name of the bin.
         """

--- a/src/fedex_generator/Operations/Filter.py
+++ b/src/fedex_generator/Operations/Filter.py
@@ -235,11 +235,11 @@ class Filter(Operation.Operation):
     def draw_figures(self, title: str, scores: pd.Series, K: int, figs_in_row: int, explanations: pd.Series,
                      bins: pd.Series,
                      influence_vals: pd.Series, source_name: str, show_scores: bool,
-                     added_text: dict | None = None) -> None:
+                     added_text: dict | None = None) -> tuple:
         if self._measure is None:
             raise ValueError(
                 "The explain method must be called first before drawing the figures via the draw_figures method.")
-        figures = self._measure.draw_figures(
+        figures, fig = self._measure.draw_figures(
             title=title, scores=scores, K=K, figs_in_row=figs_in_row,
             explanations=explanations, bins=bins, influence_vals=influence_vals,
             source_name=source_name, show_scores=show_scores, added_text=added_text
@@ -247,7 +247,7 @@ class Filter(Operation.Operation):
         if figures:
             self.correlated_notes(figures, K)
 
-        return None
+        return figures, fig
 
     def present_deleted_correlated(self, figs_in_row: int = DEFAULT_FIGS_IN_ROW):
         """

--- a/src/fedex_generator/Operations/Filter.py
+++ b/src/fedex_generator/Operations/Filter.py
@@ -151,7 +151,7 @@ class Filter(Operation.Operation):
                 figs_in_row: int = DEFAULT_FIGS_IN_ROW, show_scores: bool = False, title: str = None,
                 corr_TH: float = 0.7, explainer='fedex', consider='right', cont=None, attr=None, ignore=[],
                 use_sampling: bool = True, sample_size=Operation.SAMPLE_SIZE, debug_mode: bool = False,
-                draw_figures: bool = True, return_scores: bool = False)\
+                draw_figures: bool = True, return_scores: bool = False, measure_only: bool = False)\
             -> (None | Tuple[str, pd.Series, int, int, pd.Series, pd.Series, pd.Series, str, bool] | Tuple):
         """
         Explain for filter operation
@@ -197,6 +197,9 @@ class Filter(Operation.Operation):
 
         if use_sampling:
             self.source_df, self.result_df = source_df_backup, result_df_backup
+
+        if measure_only:
+            return scores
 
         self.delete_correlated_atts(measure, TH=corr_TH)
         if draw_figures:

--- a/src/fedex_generator/Operations/Filter.py
+++ b/src/fedex_generator/Operations/Filter.py
@@ -122,7 +122,7 @@ class Filter(Operation.Operation):
         high_correlated_columns = self.get_correlated_attributes()
 
         for attr in self.result_df.columns:
-            if isinstance(attr, str) and (attr.lower() == "index" or attr.lower() == self.attribute.lower() or \
+            if isinstance(attr, str) and (attr.lower() == "index" or (self.attribute is not None and attr.lower() == self.attribute.lower()) or \
                                           self.source_scheme.get(attr, None) == 'i' or attr in high_correlated_columns):
                 continue
             yield attr, DatasetRelation(self.source_df, self.result_df, self.source_name)

--- a/src/fedex_generator/Operations/Filter.py
+++ b/src/fedex_generator/Operations/Filter.py
@@ -151,7 +151,8 @@ class Filter(Operation.Operation):
                 figs_in_row: int = DEFAULT_FIGS_IN_ROW, show_scores: bool = False, title: str = None,
                 corr_TH: float = 0.7, explainer='fedex', consider='right', cont=None, attr=None, ignore=[],
                 use_sampling: bool = True, sample_size=Operation.SAMPLE_SIZE, debug_mode: bool = False,
-                draw_figures: bool = True) -> None | Tuple[str, pd.Series, int, int, pd.Series, pd.Series, pd.Series, str, bool]:
+                draw_figures: bool = True, return_scores: bool = False)\
+            -> (None | Tuple[str, pd.Series, int, int, pd.Series, pd.Series, pd.Series, str, bool] | Tuple):
         """
         Explain for filter operation
 
@@ -171,6 +172,7 @@ class Filter(Operation.Operation):
         :param sample_size: The sample size to use when using sampling. Can be a number or a percentage of the dataframe size. Default is 5000.
         :param debug_mode: Developer option for debugging. Disables multiprocessing when enabled. Can also be used to print additional information. Default is False.
         :param draw_figures: Whether to draw the figures at this stage, or to return the raw explanations, to be drawn later with potentially more added to them. Default is True.
+        :param return_scores: Whether to return the scores of the measure or not. Default is False.
 
         :return: explain figures
         """
@@ -206,11 +208,19 @@ class Filter(Operation.Operation):
                 self.correlated_notes(figures, top_k)
 
         else:
-            return measure.calc_influence(utils.max_key(scores), top_k=top_k, figs_in_row=figs_in_row,
+
+            ret_val = measure.calc_influence(utils.max_key(scores), top_k=top_k, figs_in_row=figs_in_row,
                                           show_scores=show_scores, title=title, debug_mode=debug_mode,
                                           draw_figures=draw_figures)
+            if return_scores:
+                return ret_val, scores
+            else:
+                return ret_val, None
 
-        return None
+        if not return_scores:
+            return None, None
+        else:
+            return None, scores
 
     def draw_figures(self, title: str, scores: pd.Series, K: int, figs_in_row: int, explanations: pd.Series,
                      bins: pd.Series,

--- a/src/fedex_generator/Operations/Filter.py
+++ b/src/fedex_generator/Operations/Filter.py
@@ -51,11 +51,11 @@ class Filter(Operation.Operation):
         self.not_presented = {}
         self.corr = self.source_df.corr(numeric_only=True)
         self.type = 'filter'
+        self.operation_str = operation_str
+        self.value = value
 
         # If the result_df is not given, we calculate it.
         if result_df is None:
-            self.operation_str = operation_str
-            self.value = value
             self.result_df = self.source_df[do_operation(self.source_df[attribute], value, operation_str)]
         else:
             self.result_df = result_df
@@ -151,7 +151,7 @@ class Filter(Operation.Operation):
                 figs_in_row: int = DEFAULT_FIGS_IN_ROW, show_scores: bool = False, title: str = None,
                 corr_TH: float = 0.7, explainer='fedex', consider='right', cont=None, attr=None, ignore=[],
                 use_sampling: bool = True, sample_size=Operation.SAMPLE_SIZE, debug_mode: bool = False,
-                draw_figures: bool = True) -> None | Tuple:
+                draw_figures: bool = True) -> None | Tuple[str, pd.Series, int, int, pd.Series, pd.Series, pd.Series, str, bool]:
         """
         Explain for filter operation
 

--- a/src/fedex_generator/Operations/GroupBy.py
+++ b/src/fedex_generator/Operations/GroupBy.py
@@ -48,7 +48,7 @@ class GroupBy(Operation.Operation):
             self.result_name = utils.get_calling_params_name(result_df)
 
         self._column_mapping = column_mapping
-
+        self._measure = None
 
     def iterate_attributes(self) -> Generator[Tuple[str, DatasetRelation], None, None]:
         """
@@ -67,11 +67,12 @@ class GroupBy(Operation.Operation):
     def get_source_col(self, filter_attr, filter_values, bins):
         return None
 
-    def explain(self, schema: dict=None, attributes: List[str]=None, top_k: int=TOP_K_DEFAULT, explainer: str='fedex',
+    def explain(self, schema: dict = None, attributes: List[str] = None, top_k: int = TOP_K_DEFAULT,
+                explainer: str = 'fedex',
                 figs_in_row: int = DEFAULT_FIGS_IN_ROW, show_scores: bool = False, title: str = None,
                 corr_TH: float = 0.7, consider='right', cont=None, attr=None, ignore=[],
                 use_sampling=True, sample_size: int | float = Operation.SAMPLE_SIZE,
-                debug_mode: bool = False
+                debug_mode: bool = False, draw_figures: bool = True
                 ):
         """
         Explain for group by operation
@@ -85,6 +86,7 @@ class GroupBy(Operation.Operation):
         :param use_sampling: whether to use sampling for the explanation.
         :param sample_size: the sample size to use when sampling the data. Can be an integer or a float between 0 and 1. Default is 5000.
         :param debug_mode: Developer option. Disables multiprocessing for easier debugging. Default is False. Can possibly add more debug options in the future.
+        :param draw_figures: Whether or not to draw the figures in this stage. Defaults to True. Set to False if you want to draw the figures later.
 
         :return: explain figures
         """
@@ -94,23 +96,34 @@ class GroupBy(Operation.Operation):
         if attributes is None:
             attributes = []
 
-
         backup_source_df, backup_res_df = None, None
         if use_sampling:
             backup_source_df, backup_res_df = self.source_df, self.result_df
-            self.source_df, self.result_df = self.sample(self.source_df, sample_size), self.sample(self.result_df, sample_size)
+            self.source_df, self.result_df = self.sample(self.source_df, sample_size), self.sample(self.result_df,
+                                                                                                   sample_size)
 
         # Unless the outlier explainer is used, the diversity measure is always used for the groupby operation.
         measure = DiversityMeasure()
+        self._measure = measure
         scores = measure.calc_measure(self, schema, attributes, ignore=ignore, unsampled_source_df=backup_source_df,
-                                      unsampled_res_df=backup_res_df, column_mapping=self._column_mapping, debug_mode=debug_mode)
-        figures = measure.calc_influence(utils.max_key(scores), top_k=top_k, figs_in_row=figs_in_row,
-                                         show_scores=show_scores, title=title, debug_mode=debug_mode)
+                                      unsampled_res_df=backup_res_df, column_mapping=self._column_mapping,
+                                      debug_mode=debug_mode)
 
         if use_sampling:
             self.source_df, self.result_df = backup_source_df, backup_res_df
 
-        return figures
+        return measure.calc_influence(utils.max_key(scores), top_k=top_k, figs_in_row=figs_in_row,
+                                          show_scores=show_scores, title=title, debug_mode=debug_mode,
+                                          draw_figures=draw_figures)
+
+
+    def draw_figures(self, title: str, scores: pd.Series, K: int, figs_in_row: int, explanations: pd.Series, bins: pd.Series,
+                      influence_vals: pd.Series, source_name: str, show_scores: bool, added_text: dict | None = None) -> None:
+        return self._measure.draw_figures(
+            title=title, scores=scores, K=K, figs_in_row=figs_in_row,
+            explanations=explanations, bins=bins, influence_vals=influence_vals,
+            source_name=source_name, show_scores=show_scores, added_text=added_text
+        )
 
     @staticmethod
     def get_one_to_many_attributes(df, group_attributes):

--- a/src/fedex_generator/Operations/GroupBy.py
+++ b/src/fedex_generator/Operations/GroupBy.py
@@ -72,8 +72,8 @@ class GroupBy(Operation.Operation):
                 figs_in_row: int = DEFAULT_FIGS_IN_ROW, show_scores: bool = False, title: str = None,
                 corr_TH: float = 0.7, consider='right', cont=None, attr=None, ignore=[],
                 use_sampling=True, sample_size: int | float = Operation.SAMPLE_SIZE,
-                debug_mode: bool = False, draw_figures: bool = True
-                ) -> None | Tuple[str, pd.Series, int, int, pd.Series, pd.Series, pd.Series, str, bool]:
+                debug_mode: bool = False, draw_figures: bool = True, return_scores: bool = False,
+                ) -> (None | Tuple[str, pd.Series, int, int, pd.Series, pd.Series, pd.Series, str, bool] | Tuple):
         """
         Explain for group by operation
         :param schema: dictionary with new columns names, in case {'col_name': 'i'} will be ignored in the explanation
@@ -112,9 +112,13 @@ class GroupBy(Operation.Operation):
         if use_sampling:
             self.source_df, self.result_df = backup_source_df, backup_res_df
 
-        return measure.calc_influence(utils.max_key(scores), top_k=top_k, figs_in_row=figs_in_row,
+        ret_val = measure.calc_influence(utils.max_key(scores), top_k=top_k, figs_in_row=figs_in_row,
                                           show_scores=show_scores, title=title, debug_mode=debug_mode,
                                           draw_figures=draw_figures)
+        if return_scores:
+            return ret_val, scores
+        else:
+            return ret_val, None
 
 
     def draw_figures(self, title: str, scores: pd.Series, K: int, figs_in_row: int, explanations: pd.Series, bins: pd.Series,

--- a/src/fedex_generator/Operations/GroupBy.py
+++ b/src/fedex_generator/Operations/GroupBy.py
@@ -73,6 +73,7 @@ class GroupBy(Operation.Operation):
                 corr_TH: float = 0.7, consider='right', cont=None, attr=None, ignore=[],
                 use_sampling=True, sample_size: int | float = Operation.SAMPLE_SIZE,
                 debug_mode: bool = False, draw_figures: bool = True, return_scores: bool = False,
+                measure_only: bool = False
                 ) -> (None | Tuple[str, pd.Series, int, int, pd.Series, pd.Series, pd.Series, str, bool] | Tuple):
         """
         Explain for group by operation
@@ -111,6 +112,9 @@ class GroupBy(Operation.Operation):
 
         if use_sampling:
             self.source_df, self.result_df = backup_source_df, backup_res_df
+
+        if measure_only:
+            return scores
 
         ret_val = measure.calc_influence(utils.max_key(scores), top_k=top_k, figs_in_row=figs_in_row,
                                           show_scores=show_scores, title=title, debug_mode=debug_mode,

--- a/src/fedex_generator/Operations/GroupBy.py
+++ b/src/fedex_generator/Operations/GroupBy.py
@@ -73,7 +73,7 @@ class GroupBy(Operation.Operation):
                 corr_TH: float = 0.7, consider='right', cont=None, attr=None, ignore=[],
                 use_sampling=True, sample_size: int | float = Operation.SAMPLE_SIZE,
                 debug_mode: bool = False, draw_figures: bool = True
-                ):
+                ) -> None | Tuple[str, pd.Series, int, int, pd.Series, pd.Series, pd.Series, str, bool]:
         """
         Explain for group by operation
         :param schema: dictionary with new columns names, in case {'col_name': 'i'} will be ignored in the explanation

--- a/src/fedex_generator/Operations/GroupBy.py
+++ b/src/fedex_generator/Operations/GroupBy.py
@@ -126,7 +126,7 @@ class GroupBy(Operation.Operation):
 
 
     def draw_figures(self, title: str, scores: pd.Series, K: int, figs_in_row: int, explanations: pd.Series, bins: pd.Series,
-                      influence_vals: pd.Series, source_name: str, show_scores: bool, added_text: dict | None = None) -> None:
+                      influence_vals: pd.Series, source_name: str, show_scores: bool, added_text: dict | None = None) -> tuple:
         return self._measure.draw_figures(
             title=title, scores=scores, K=K, figs_in_row=figs_in_row,
             explanations=explanations, bins=bins, influence_vals=influence_vals,

--- a/src/fedex_generator/Operations/Join.py
+++ b/src/fedex_generator/Operations/Join.py
@@ -150,7 +150,7 @@ class Join(Operation.Operation):
             return ret_val, None
 
     def draw_figures(self, title: str, scores: pd.Series, K: int, figs_in_row: int, explanations: pd.Series, bins: pd.Series,
-                      influence_vals: pd.Series, source_name: str, show_scores: bool, added_text: dict | None = None) -> None:
+                      influence_vals: pd.Series, source_name: str, show_scores: bool, added_text: dict | None = None) -> tuple:
         return self._measure.draw_figures(
             title=title, scores=scores, K=K, figs_in_row=figs_in_row,
             explanations=explanations, bins=bins, influence_vals=influence_vals,

--- a/src/fedex_generator/Operations/Join.py
+++ b/src/fedex_generator/Operations/Join.py
@@ -74,8 +74,8 @@ class Join(Operation.Operation):
                 figs_in_row: int = DEFAULT_FIGS_IN_ROW, show_scores: bool = False, title: str = None,
                 corr_TH: float = 0.7, explainer='fedex', consider='right', cont=None, attr=None, ignore=[],
                 use_sampling: bool = True, sample_size: int | float = Operation.SAMPLE_SIZE,
-                debug_mode: bool = False, draw_figures: bool = False
-                ) -> None | Tuple[str, pd.Series, int, int, pd.Series, pd.Series, pd.Series, str, bool]:
+                debug_mode: bool = False, draw_figures: bool = False, return_scores: bool = False
+                ) -> None | Tuple[str, pd.Series, int, int, pd.Series, pd.Series, pd.Series, str, bool] | Tuple:
         """
         Explain for filter operation
 
@@ -89,6 +89,7 @@ class Join(Operation.Operation):
         :param sample_size: the size of the sample to use. Can be a percentage of the dataframe size if below 1. Default is 5000.
         :param debug_mode: Developer option. Disables multiprocessing for easier debugging. Default is False. Can possibly add more debug options in the future.
         :param draw_figures: Whether or not to draw the figures in this stage. Defaults to True. Set to False if you want to draw the figures later.
+        :param return_scores: Whether or not to return the scores. Defaults to False.
 
         :return: explain figures
         """
@@ -109,7 +110,7 @@ class Join(Operation.Operation):
             #     exp += '\n and then\n'
             #     exp += str(facts[fact_idx][0])
             #     top_k -= 1
-            return
+            return None
         if attributes is None:
             attributes = []
 
@@ -135,9 +136,14 @@ class Join(Operation.Operation):
         if use_sampling:
             self.left_df, self.right_df, self.result_df = backup_left_df, backup_right_df, backup_res_df
 
-        return measure.calc_influence(utils.max_key(scores), top_k=top_k, figs_in_row=figs_in_row,
+        ret_val = measure.calc_influence(utils.max_key(scores), top_k=top_k, figs_in_row=figs_in_row,
                                       show_scores=show_scores, title=title, debug_mode=debug_mode,
                                       draw_figures=draw_figures)
+
+        if return_scores:
+            return ret_val, scores
+        else:
+            return ret_val, None
 
     def draw_figures(self, title: str, scores: pd.Series, K: int, figs_in_row: int, explanations: pd.Series, bins: pd.Series,
                       influence_vals: pd.Series, source_name: str, show_scores: bool, added_text: dict | None = None) -> None:

--- a/src/fedex_generator/Operations/Join.py
+++ b/src/fedex_generator/Operations/Join.py
@@ -75,7 +75,7 @@ class Join(Operation.Operation):
                 corr_TH: float = 0.7, explainer='fedex', consider='right', cont=None, attr=None, ignore=[],
                 use_sampling: bool = True, sample_size: int | float = Operation.SAMPLE_SIZE,
                 debug_mode: bool = False, draw_figures: bool = False
-                ):
+                ) -> None | Tuple[str, pd.Series, int, int, pd.Series, pd.Series, pd.Series, str, bool]:
         """
         Explain for filter operation
 

--- a/src/fedex_generator/Operations/Join.py
+++ b/src/fedex_generator/Operations/Join.py
@@ -74,7 +74,8 @@ class Join(Operation.Operation):
                 figs_in_row: int = DEFAULT_FIGS_IN_ROW, show_scores: bool = False, title: str = None,
                 corr_TH: float = 0.7, explainer='fedex', consider='right', cont=None, attr=None, ignore=[],
                 use_sampling: bool = True, sample_size: int | float = Operation.SAMPLE_SIZE,
-                debug_mode: bool = False, draw_figures: bool = False, return_scores: bool = False
+                debug_mode: bool = False, draw_figures: bool = False, return_scores: bool = False,
+                measure_only: bool = False
                 ) -> None | Tuple[str, pd.Series, int, int, pd.Series, pd.Series, pd.Series, str, bool] | Tuple:
         """
         Explain for filter operation
@@ -135,6 +136,9 @@ class Join(Operation.Operation):
 
         if use_sampling:
             self.left_df, self.right_df, self.result_df = backup_left_df, backup_right_df, backup_res_df
+
+        if measure_only:
+            return scores
 
         ret_val = measure.calc_influence(utils.max_key(scores), top_k=top_k, figs_in_row=figs_in_row,
                                       show_scores=show_scores, title=title, debug_mode=debug_mode,

--- a/src/fedex_generator/Operations/Join.py
+++ b/src/fedex_generator/Operations/Join.py
@@ -15,8 +15,9 @@ class Join(Operation.Operation):
     Implementation of the Join operation, fit for the FEDEx explainability framework.\n
     Provides a .explain() method for explaining the operation, as well as methods used for producing the explanation.
     """
+
     def __init__(self, left_df: DataFrame, right_df: DataFrame, source_scheme: dict, attribute: str,
-                 result_df: DataFrame=None, left_name: str=None, right_name: str=None):
+                 result_df: DataFrame = None, left_name: str = None, right_name: str = None):
         """
         :param left_df: DataFrame to join on the left side.
         :param right_df: DataFrame to join on the right side.
@@ -47,7 +48,7 @@ class Join(Operation.Operation):
         self.left_df = left_df
         self.right_df = right_df
         self.result_df = result_df
-
+        self._measure = None
 
     def iterate_attributes(self) -> Generator[Tuple[str, DatasetRelation], None, None]:
         """
@@ -69,11 +70,11 @@ class Join(Operation.Operation):
                 continue
             yield attr, DatasetRelation(self.right_df, self.result_df, self.right_name)
 
-    def explain(self, schema: dict=None, attributes: List[str]=None, top_k: int=TOP_K_DEFAULT,
+    def explain(self, schema: dict = None, attributes: List[str] = None, top_k: int = TOP_K_DEFAULT,
                 figs_in_row: int = DEFAULT_FIGS_IN_ROW, show_scores: bool = False, title: str = None,
                 corr_TH: float = 0.7, explainer='fedex', consider='right', cont=None, attr=None, ignore=[],
                 use_sampling: bool = True, sample_size: int | float = Operation.SAMPLE_SIZE,
-                debug_mode: bool = False
+                debug_mode: bool = False, draw_figures: bool = False
                 ):
         """
         Explain for filter operation
@@ -87,14 +88,17 @@ class Join(Operation.Operation):
         :param use_sampling: whether to use sampling or not
         :param sample_size: the size of the sample to use. Can be a percentage of the dataframe size if below 1. Default is 5000.
         :param debug_mode: Developer option. Disables multiprocessing for easier debugging. Default is False. Can possibly add more debug options in the future.
+        :param draw_figures: Whether or not to draw the figures in this stage. Defaults to True. Set to False if you want to draw the figures later.
 
         :return: explain figures
         """
 
         if explainer == 'shapley':
             measure = ShapleyMeasure()
-        # else: score = 0
-            top_fact, facts = measure.get_most_contributing_fact(self, self.left_df, self.right_df, self.attribute,None, consider=consider, top_k=top_k, cont=cont, att=attr)
+            # else: score = 0
+            top_fact, facts = measure.get_most_contributing_fact(self, self.left_df, self.right_df, self.attribute,
+                                                                 None, consider=consider, top_k=top_k, cont=cont,
+                                                                 att=attr)
             # exp = f'The result of joining dataframes \'{self.left_name}\' and \'{self.right_name}\' on attribute \'{self.attribute}\' is not empty.\nThe following fact from dataframe \'{self.left_name}\' has significantly contributed to this result:\n'
             # facts = list({k: v for k, v in sorted(facts.items(), key=lambda item: -item[1])}.items())
             # fact_idx = 0
@@ -105,7 +109,7 @@ class Join(Operation.Operation):
             #     exp += '\n and then\n'
             #     exp += str(facts[fact_idx][0])
             #     top_k -= 1
-            return 
+            return
         if attributes is None:
             attributes = []
 
@@ -115,7 +119,8 @@ class Join(Operation.Operation):
         backup_left_df, backup_right_df, backup_res_df, combined_source_df = None, None, None, None
         if use_sampling:
             backup_left_df, backup_right_df, backup_res_df = self.left_df, self.right_df, self.result_df
-            self.left_df, self.right_df, self.result_df = self.sample(self.left_df, sample_size), self.sample(self.right_df, sample_size), self.sample(self.result_df, sample_size)
+            self.left_df, self.right_df, self.result_df = self.sample(self.left_df, sample_size), self.sample(
+                self.right_df, sample_size), self.sample(self.result_df, sample_size)
             # If sampling is used, calc_measure needs an unsampled source_df to create bins for its score dict, otherwise
             # the explanation creation will be affected by the sampling, and not just the measure calculation.
             # Therefore, we concat the left and right DataFrames to create the unsampled source DataFrame.
@@ -123,13 +128,21 @@ class Join(Operation.Operation):
 
         # When using the FEDEx explainer, the exceptionality measure is used to calculate the explanation.
         measure = ExceptionalityMeasure()
+        self._measure = measure
         scores = measure.calc_measure(self, schema, attributes, unsampled_source_df=combined_source_df,
                                       unsampled_res_df=backup_res_df, debug_mode=debug_mode)
-
-        figures = measure.calc_influence(utils.max_key(scores), top_k=top_k, figs_in_row=figs_in_row,
-                                         show_scores=show_scores, title=title, debug_mode=debug_mode)
 
         if use_sampling:
             self.left_df, self.right_df, self.result_df = backup_left_df, backup_right_df, backup_res_df
 
-        return figures
+        return measure.calc_influence(utils.max_key(scores), top_k=top_k, figs_in_row=figs_in_row,
+                                      show_scores=show_scores, title=title, debug_mode=debug_mode,
+                                      draw_figures=draw_figures)
+
+    def draw_figures(self, title: str, scores: pd.Series, K: int, figs_in_row: int, explanations: pd.Series, bins: pd.Series,
+                      influence_vals: pd.Series, source_name: str, show_scores: bool, added_text: dict | None = None) -> None:
+        return self._measure.draw_figures(
+            title=title, scores=scores, K=K, figs_in_row=figs_in_row,
+            explanations=explanations, bins=bins, influence_vals=influence_vals,
+            source_name=source_name, show_scores=show_scores, added_text=added_text
+        )

--- a/src/fedex_generator/Operations/Operation.py
+++ b/src/fedex_generator/Operations/Operation.py
@@ -51,6 +51,23 @@ class Operation:
         """
         raise NotImplementedError()
 
+    def draw_figures(self, title: str, scores: pd.Series, K: int, figs_in_row: int, explanations: pd.Series, bins: pd.Series,
+                      influence_vals: pd.Series, source_name: str, show_scores: bool, added_text: dict | None = None) -> None:
+        """
+        Draws the figures for the explanations.
+        :param title: The title of the plot.
+        :param scores: The scores of the attributes.
+        :param K: The number of top attributes to consider.
+        :param figs_in_row: The number of figures to display in a row.
+        :param explanations: The explanations generated for the top K attributes.
+        :param bins: The bins of the attributes.
+        :param influence_vals: The influence values of the attributes.
+        :param source_name: The name of the source DataFrame.
+        :param show_scores: Whether to show the scores on the plot.
+        :param added_text: Additional text to add to the bottom of each figure. Optional. A dict with explanation as key, and a sub-dict with 'text' and 'position' as keys.
+        """
+        raise NotImplementedError()
+
     def present_deleted_correlated(self, figs_in_row: int = DEFAULT_FIGS_IN_ROW):
         """
         Present the attributes that were deleted due to high correlation.


### PR DESCRIPTION
Added options to FEDEx code that allow the adding of additional text to plots in specific locations, allowing pd-explain to inject its new LLM reasoning feature into fedex plots.
Changed FEDEx visualization functions such that they now always return the figure they generate.
Made it so Filter's plot title now includes the query itself, instead of stating "Filter on....

Bugs fixed:

- Using wrong append function when there are missing values in _select_top_columns in DiversityMeasure. caused AttributeError.
- Wrong values could be added to the plot if there were missing values after selecting using _select_top_columns.
- Crash in Filter when the result is a series and not a dataframe.
- DiversityMeasure's get_agg_func_from_name sometimes threw an IndexError instead of continuing.
- Filter's iterate_attributes would treat None as a string (and throw an error).
- get_agg_func_by_name - if agg func was a string, we could iterate over the string, getting meaningless results which would then cause an exception.
- If name was passed to the function as a column name without an aggregation suffix, we would get an exception.
- Title of plots would sometimes intersect with the plots. Adjusted height of title to mitigate the issue.