### PR TITLE
Small visualization patch

### DIFF
--- a/src/fedex_generator/Measures/BaseMeasure.py
+++ b/src/fedex_generator/Measures/BaseMeasure.py
@@ -459,9 +459,18 @@ class BaseMeasure(object):
                 fig, axes = plt.subplots(figsize=(9, 11))
             # Otherwise, use a smaller figure size.
             else:
-                fig, axes = plt.subplots(figsize=(5, 6))
+                fig, axes = plt.subplots(figsize=(7, 8))
 
-        fig.suptitle(title, fontsize=20, y=1.02)
+        # There are issues of the title not being properly centered when there is only one explanation,
+        # so we need to check if there is only one explanation, and if so, set the title to be centered.
+        if num_explanations == 1:
+            # Why does x=0.6 work? I don't know, but it does and it centers the title properly.
+            # Not 0.5, for some reason beyond my understanding.
+            fig.suptitle(title, fontsize=15, y=1.02, x=0.6)
+            axes.set_title(explanations.iloc[0], fontsize=16)
+            axes.set_axis_off()
+        else:
+            fig.suptitle(title, fontsize=20, y=1.02)
 
         if num_explanations > 1:
             axes = axes.flatten()  # Flatten the axes array for easier indexing.
@@ -474,7 +483,7 @@ class BaseMeasure(object):
         for index, (explanation, current_bin, current_influence_vals, score) in enumerate(
                 zip(explanations, bins, influence_vals, scores)):
 
-            explanation_num = index + 1 if num_explanations > 1 else None
+            explanation_num = index + 1 if (num_explanations > 1 and added_text is not None) else None
 
             figure = self.draw_bar(current_bin, current_influence_vals, title=explanation,
                                 ax=axes[index], score=score,

--- a/src/fedex_generator/Measures/BaseMeasure.py
+++ b/src/fedex_generator/Measures/BaseMeasure.py
@@ -345,7 +345,7 @@ class BaseMeasure(object):
         return explanation
 
     def draw_bar(self, bin_item: Bin, influence_vals: dict = None, title: str = None, ax=None, score=None,
-                 show_scores: bool = False) -> None:
+                 show_scores: bool = False, explanation_num: int | None = None) -> None:
         """
         Draw a bar plot for the given bin item and influence values.
         This is an abstract method, and should be implemented by the inheriting class.
@@ -355,6 +355,7 @@ class BaseMeasure(object):
         :param ax: The axes to draw the plot on. Optional.
         :param score: The score of the bin item. Optional.
         :param show_scores: Whether to show the scores on the plot. Optional.
+        :param explanation_num: The explanation number to display in the title. Optional.
         """
         raise NotImplementedError()
 
@@ -467,64 +468,42 @@ class BaseMeasure(object):
         else:
             axes = [axes]
 
+        added_text_text = ""
+
         # Draw the bar plots for each explanation
         for index, (explanation, current_bin, current_influence_vals, score) in enumerate(
                 zip(explanations, bins, influence_vals, scores)):
 
+            explanation_num = index + 1 if num_explanations > 1 else None
+
             figure = self.draw_bar(current_bin, current_influence_vals, title=explanation,
                                 ax=axes[index], score=score,
-                                show_scores=show_scores)  ###
+                                show_scores=show_scores,
+                                explanation_num=explanation_num
+                                   )
             if figure:
                 figures.append(figure)
 
-        if added_text is not None:
-            # Draw the figure to establish precise bounding boxes
-            plt.draw()
-            for explanation, ax in zip(explanations, axes):
-                renderer = ax.figure.canvas.get_renderer()
-                max_label_height = 0
+            if added_text is not None:
+                explanation_added_text = added_text.get(explanation, None)
+                if explanation_added_text is not None:
+                    explanation_added_text = explanation_added_text.get('added_text', "")
+                    if not isinstance(explanation_added_text, str):
+                        explanation_added_text = str(explanation_added_text)
+                    # Replace any wrapping done previously - we want our own custom wrapping here, since we know
+                    # what length of text we want to display.
+                    explanation_added_text = explanation_added_text.replace("\n", " ")
+                    if explanation_num is not None:
+                        added_text_text += f"{START_BOLD}[{explanation_num}]{END_BOLD} {explanation_added_text}\n\n"
+                    else:
+                        added_text_text += f"{explanation_added_text}\n\n"
 
-                # Check all x-tick labels plus the x-axis label itself to find the maximum height
-                for label in ax.get_xticklabels() + [ax.xaxis.get_label()]:
-                    bbox = label.get_window_extent(renderer=renderer)
-                    if bbox.height > max_label_height:
-                        max_label_height = bbox.height
 
+        # If there is text to add, add it to the bottom left of the plot.
+        if added_text_text:
+            plt.figtext(0, 0, added_text_text, horizontalalignment='left', verticalalignment='top',
+                        fontsize=16, wrap=True,)
 
-
-                # Add a little bit of padding
-                added_text_dict = added_text[explanation]
-                text = added_text_dict["added_text"]
-                position = added_text_dict["position"]
-
-                if position == "bottom":
-                    offset_in_points = -(max_label_height + 10)
-
-                    ax.annotate(
-                        text,
-                        xy=(0.5, 0),  # anchor at the bottom of the axes
-                        xycoords='axes fraction',
-                        xytext=(0, offset_in_points),
-                        textcoords='offset points',
-                        ha='center', va='top',
-                        fontsize=16
-                    )
-                elif position == "top":
-                    offset_in_points = max_label_height + 10
-
-                    ax.annotate(
-                        text,
-                        xy=(0.5, 1),  # anchor at the top of the axes
-                        xycoords='axes fraction',
-                        xytext=(0, offset_in_points),
-                        textcoords='offset points',
-                        ha='center', va='bottom',
-                        fontsize=16
-                    )
-
-            # Adding hspace of 1.5 seems to generally give enough space for the added text, without
-            # squishing the plots too much or leaving too much empty space.
-            plt.subplots_adjust(hspace=1.5)
         # Adding a bit of a top margin to the plot, to make sure the title doesn't interfere with the plots.
         plt.subplots_adjust(top=0.92)
         plt.tight_layout()

--- a/src/fedex_generator/Measures/DiversityMeasure.py
+++ b/src/fedex_generator/Measures/DiversityMeasure.py
@@ -206,7 +206,7 @@ class DiversityMeasure(BaseMeasure):
         # return list(self.operation_object.agg_dict.values())[0][aggregation_index]
 
     def draw_bar(self, bin_item: MultiIndexBin, influence_vals: dict = None, title=None, ax=None, score=None,
-                 show_scores: bool = False):
+                 show_scores: bool = False, explanation_num: int | None = None):
         """
         Draw a bar chart for a given bin item with optional features.
 
@@ -219,6 +219,7 @@ class DiversityMeasure(BaseMeasure):
         :param ax: Optional; the matplotlib axes object to draw the bar chart on.
         :param score: Optional; the score to be displayed in the title if `show_scores` is True.
         :param show_scores: Optional; a boolean indicating whether to display the score in the title (default is False).
+        :param explanation_num: Optional; an integer representing the explanation number to be included in the title.
         """
         try:
             # Get the index of the maximum value and its influence
@@ -258,6 +259,8 @@ class DiversityMeasure(BaseMeasure):
 
             # Get the aggregated values for the labels, and draw the bar chart
             aggregate_column = [aggregated_result.get(item, 0) for item in labels]
+            if explanation_num is not None:
+                title = f"{START_BOLD}[{explanation_num}]{END_BOLD} {title}" if title else f"{START_BOLD}[{explanation_num}]{END_BOLD}"
             if show_scores:
                 ax.set_title(f'score: {score}\n{utils.to_valid_latex(title)}', fontdict={'fontsize': 10})
             else:
@@ -278,6 +281,8 @@ class DiversityMeasure(BaseMeasure):
                 columns = self._select_top_columns(influence_vals, columns, max_value, max_group_value)
 
             title = self._fix_explanation(title, columns, max_value, max_group_value)
+            if explanation_num is not None:
+                title = f"{START_BOLD}[{explanation_num}]{END_BOLD} {title}" if title else f"{START_BOLD}[{explanation_num}]{END_BOLD}"
             ax.set_title(utils.to_valid_latex(title), fontdict={'fontsize': 20})
 
             draw_bar(list(columns.index),

--- a/src/fedex_generator/Measures/DiversityMeasure.py
+++ b/src/fedex_generator/Measures/DiversityMeasure.py
@@ -271,6 +271,10 @@ class DiversityMeasure(BaseMeasure):
                      ax=ax)
             ax.set_axis_on()
 
+            # Rotate the x-axis labels for better readability, if there are over 8 labels
+            if len(labels) > 8:
+                ax.set_xticklabels(labels, rotation=45, tickdir='in')
+
         except Exception as e:
             # In the case of an exception, draw a bar chart using the draw_bar method defined outside the class
             columns = bin_item.get_binned_result_column()
@@ -293,6 +297,9 @@ class DiversityMeasure(BaseMeasure):
                      ax=ax,
                      )
 
+            # Rotate the x-axis labels for better readability, if there are over 8 labels
+            if len(columns) > 8:
+                ax.set_xticklabels(columns.index, rotation=45, tickdir='in')
             ax.set_axis_on()
 
 

--- a/src/fedex_generator/Measures/DiversityMeasure.py
+++ b/src/fedex_generator/Measures/DiversityMeasure.py
@@ -273,7 +273,7 @@ class DiversityMeasure(BaseMeasure):
 
             # Rotate the x-axis labels for better readability, if there are over 8 labels
             if len(labels) > 8:
-                ax.set_xticklabels(labels, rotation=45, tickdir='in')
+                ax.tick_params(axis='x', rotation=45, tickdir='in')
 
         except Exception as e:
             # In the case of an exception, draw a bar chart using the draw_bar method defined outside the class
@@ -299,7 +299,7 @@ class DiversityMeasure(BaseMeasure):
 
             # Rotate the x-axis labels for better readability, if there are over 8 labels
             if len(columns) > 8:
-                ax.set_xticklabels(columns.index, rotation=45, tickdir='in')
+                ax.tick_params(axis='x', rotation=45, tickdir='in')
             ax.set_axis_on()
 
 

--- a/src/fedex_generator/Measures/ExceptionalityMeasure.py
+++ b/src/fedex_generator/Measures/ExceptionalityMeasure.py
@@ -100,6 +100,10 @@ class ExceptionalityMeasure(BaseMeasure):
             else:
                 ax.set_title(utils.to_valid_latex(title), fontdict={'fontsize': 20})
 
+        # Rotate the x-axis labels by 45 degrees if there are more than 8 labels
+        if len(labels) > 8:
+            ax.tick_params(axis='x', rotation=45, tickdir='in')
+
         ax.set_axis_on()
         return bin_item.get_bin_name()  ####
 

--- a/src/fedex_generator/Measures/ExceptionalityMeasure.py
+++ b/src/fedex_generator/Measures/ExceptionalityMeasure.py
@@ -33,7 +33,7 @@ class ExceptionalityMeasure(BaseMeasure):
         super().__init__()
 
     def draw_bar(self, bin_item: Bin, influence_vals: dict = None, title=None, ax=None, score=None,
-                 show_scores: bool = False) -> str:
+                 show_scores: bool = False, explanation_num: int | None = None) -> str:
         """
         Draw a bar chart comparing the distribution of values before and after an operation.
 
@@ -92,6 +92,8 @@ class ExceptionalityMeasure(BaseMeasure):
         ax.set_ylabel("frequency(\\%)", fontsize=16)
 
         # Set the title of the bar chart. If show_scores is True, display the score in the title
+        if explanation_num is not None:
+            title = f"{START_BOLD}[{explanation_num}]{END_BOLD} {title}" if title is not None else f"{START_BOLD}[{explanation_num}]{END_BOLD}"
         if title is not None:
             if show_scores:
                 ax.set_title(f'score: {score}\n {utils.to_valid_latex(title)}', fontdict={'fontsize': 20})

--- a/src/fedex_generator/Operations/Filter.py
+++ b/src/fedex_generator/Operations/Filter.py
@@ -299,7 +299,7 @@ class Filter(Operation.Operation):
             plt.figtext(0, 0, txt, horizontalalignment='left', verticalalignment='top')
         else:
             # If there is already text added, we add the notes below the existing text.
-            plt.figtext(0, -0.05 * (lentxt + 1), txt, horizontalalignment='left', verticalalignment='top')
+            plt.figtext(0, -0.07 * (lentxt + 1), txt, horizontalalignment='left', verticalalignment='top', fontsize=16)
 
     def delete_correlated_atts(self, measure, TH=0.7):
         """

--- a/src/fedex_generator/Operations/Filter.py
+++ b/src/fedex_generator/Operations/Filter.py
@@ -245,7 +245,7 @@ class Filter(Operation.Operation):
             source_name=source_name, show_scores=show_scores, added_text=added_text
         )
         if figures:
-            self.correlated_notes(figures, K)
+            self.correlated_notes(figures, K, added_text_exists= added_text is not None)
 
         return figures, fig
 
@@ -264,7 +264,7 @@ class Filter(Operation.Operation):
         measure = ExceptionalityMeasure()
         measure.calc_influence(deleted=self.not_presented, figs_in_row=figs_in_row)
 
-    def correlated_notes(self, figures, top_k) -> None:
+    def correlated_notes(self, figures, top_k, added_text_exists: bool = False) -> None:
         """
         Add notes about correlated attributes to the figures.
 
@@ -274,6 +274,8 @@ class Filter(Operation.Operation):
 
         :param figures: The list of figures to add notes to.
         :param top_k: The number of top attributes to consider.
+        :param added_text_exists: A flag indicating whether additional text has been added to the figures. If yes, the
+        notes will be added below the existing text. Default is False.
         """
         txt = ""
         lentxt = 0
@@ -293,7 +295,11 @@ class Filter(Operation.Operation):
             txt += "\nIn order to view the not presented attributes, please execute the following: df.present_deleted_correlated()"
 
         # Add the notes to the figures and show them.
-        plt.figtext(0, 0, txt, horizontalalignment='left', verticalalignment='top')
+        if not added_text_exists:
+            plt.figtext(0, 0, txt, horizontalalignment='left', verticalalignment='top')
+        else:
+            # If there is already text added, we add the notes below the existing text.
+            plt.figtext(0, -0.05 * (lentxt + 1), txt, horizontalalignment='left', verticalalignment='top')
 
     def delete_correlated_atts(self, measure, TH=0.7):
         """


### PR DESCRIPTION
Moved additional text for the plots (such as LLM text generated in pd-explain) to the bottom left corner, instead of beneath the plots. 
Made sure title is always centered, even when k=1, and increased k=1 plot size (previously, plot would get squished often when k=1).
Fixed rotation of x labels to always apply when there are too many labels.