### PR TITLE
Minor visualization patch for the case where there is added text from an outside source.

### DIFF
--- a/src/fedex_generator/Measures/BaseMeasure.py
+++ b/src/fedex_generator/Measures/BaseMeasure.py
@@ -417,7 +417,8 @@ class BaseMeasure(object):
 
 
     def draw_figures(self, title: str, scores: pd.Series, K: int, figs_in_row: int, explanations: pd.Series, bins: pd.Series,
-                      influence_vals: pd.Series, source_name: str, show_scores: bool, added_text: dict | None = None)\
+                      influence_vals: pd.Series, source_name: str, show_scores: bool,
+                     added_text: pd.Series = None, added_text_name: str | None = None)\
             -> tuple[list[str], plt.Figure] | None:
         """
         Draws the figures for the explanations.
@@ -431,6 +432,7 @@ class BaseMeasure(object):
         :param source_name: The name of the source DataFrame.
         :param show_scores: Whether to show the scores on the plot.
         :param added_text: Additional text to add to the bottom of each figure. Optional. A dict with explanation as key, and a sub-dict with 'text' and 'position' as keys.
+        :param added_text_name: The name of the added text, to be displayed right above the added text.
         :return: A list of matplotlib figures containing the explanations for the top k attributes, after computing the influence.
         """
         figures = []
@@ -477,7 +479,7 @@ class BaseMeasure(object):
         else:
             axes = [axes]
 
-        added_text_text = ""
+        added_text_text = f"{added_text_name}:\n\n" if added_text_name else ""
 
         # Draw the bar plots for each explanation
         for index, (explanation, current_bin, current_influence_vals, score) in enumerate(

--- a/src/fedex_generator/Operations/GroupBy.py
+++ b/src/fedex_generator/Operations/GroupBy.py
@@ -126,11 +126,13 @@ class GroupBy(Operation.Operation):
 
 
     def draw_figures(self, title: str, scores: pd.Series, K: int, figs_in_row: int, explanations: pd.Series, bins: pd.Series,
-                      influence_vals: pd.Series, source_name: str, show_scores: bool, added_text: dict | None = None) -> tuple:
+                      influence_vals: pd.Series, source_name: str, show_scores: bool,
+                     added_text: dict | None = None, added_text_name: str | None = None) -> tuple:
         return self._measure.draw_figures(
             title=title, scores=scores, K=K, figs_in_row=figs_in_row,
             explanations=explanations, bins=bins, influence_vals=influence_vals,
-            source_name=source_name, show_scores=show_scores, added_text=added_text
+            source_name=source_name, show_scores=show_scores, added_text=added_text,
+            added_text_name=added_text_name
         )
 
     @staticmethod

--- a/src/fedex_generator/Operations/Join.py
+++ b/src/fedex_generator/Operations/Join.py
@@ -150,9 +150,11 @@ class Join(Operation.Operation):
             return ret_val, None
 
     def draw_figures(self, title: str, scores: pd.Series, K: int, figs_in_row: int, explanations: pd.Series, bins: pd.Series,
-                      influence_vals: pd.Series, source_name: str, show_scores: bool, added_text: dict | None = None) -> tuple:
+                      influence_vals: pd.Series, source_name: str, show_scores: bool,
+                     added_text: dict | None = None, added_text_name: str | None = None) -> tuple:
         return self._measure.draw_figures(
             title=title, scores=scores, K=K, figs_in_row=figs_in_row,
             explanations=explanations, bins=bins, influence_vals=influence_vals,
-            source_name=source_name, show_scores=show_scores, added_text=added_text
+            source_name=source_name, show_scores=show_scores, added_text=added_text,
+            added_text_name=added_text_name
         )

--- a/src/fedex_generator/Operations/Operation.py
+++ b/src/fedex_generator/Operations/Operation.py
@@ -52,7 +52,8 @@ class Operation:
         raise NotImplementedError()
 
     def draw_figures(self, title: str, scores: pd.Series, K: int, figs_in_row: int, explanations: pd.Series, bins: pd.Series,
-                      influence_vals: pd.Series, source_name: str, show_scores: bool, added_text: dict | None = None) -> None:
+                      influence_vals: pd.Series, source_name: str, show_scores: bool,
+                     added_text: dict | None = None, added_text_name: str | None = None) -> None:
         """
         Draws the figures for the explanations.
         :param title: The title of the plot.
@@ -65,6 +66,7 @@ class Operation:
         :param source_name: The name of the source DataFrame.
         :param show_scores: Whether to show the scores on the plot.
         :param added_text: Additional text to add to the bottom of each figure. Optional. A dict with explanation as key, and a sub-dict with 'text' and 'position' as keys.
+        :param added_text_name: The name of the additional text to be displayed. Optional. If provided, it will be displayed above the added text.
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
Added small title for added text sent in by external sources (such as LLM added text from pd-explain).

Further adjusted spacing between added text and correlation notes in Filter.py and made a clear distinction between the two.